### PR TITLE
비로그인에서 profile로 이동 시 404 라우팅 방지

### DIFF
--- a/apps/frontend/src/layouts/Sidebar.tsx
+++ b/apps/frontend/src/layouts/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { css, useTheme } from '@emotion/react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import SVGIcon from '@/comp/SVGIcon';
 import { useAuthUser, useIsLoggedIn } from '@/store/authStore';
@@ -14,15 +14,10 @@ const NAV_ITEMS = [
 
 export const Sidebar = () => {
   const theme = useTheme();
-  const location = useLocation();
   const isLoggedIn = useIsLoggedIn();
   const user = useAuthUser();
 
-  const activeItemId = NAV_ITEMS.find(item =>
-    item.id === 'profile'
-      ? location.pathname.startsWith('/profile')
-      : location.pathname === item.path,
-  )?.id;
+  const activeItemId = NAV_ITEMS.find(item => location.pathname === item.path)?.id;
 
   return (
     <aside css={sidebarStyle(theme)}>

--- a/apps/frontend/src/pages/user/Profile.tsx
+++ b/apps/frontend/src/pages/user/Profile.tsx
@@ -1,6 +1,16 @@
-import { useParams } from 'react-router-dom';
+import { useParams, Navigate } from 'react-router-dom';
+import { useAuthUser } from '@/store/authStore';
 
 export const Profile = () => {
-  const { userId } = useParams<{ userId: string }>();
-  return <div>Profile Page - User ID: {userId}</div>;
+  const { userId } = useParams();
+  const user = useAuthUser();
+
+  if (!userId && user?.id) return <Navigate to={`/profile/${user.id}`} replace />;
+  if (!userId && !user) return <Navigate to="/login" replace />;
+
+  return (
+    <div>
+      <h1>Profile Page: {userId}</h1>
+    </div>
+  );
 };

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -77,7 +77,7 @@ export const router = createBrowserRouter([
     children: [
       { path: '/streak', element: <Streak /> },
       { path: '/leaderboard', element: <Leaderboard /> },
-      { path: '/profile/:userId', element: <Profile /> },
+      { path: '/profile/:userId?', element: <Profile /> },
       { path: '/setting', element: <Setting /> },
     ],
   },


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 10m
- 실제 작업 시간: 10m

<br/>

## 📌 작업 요약

기존: 사이드에서 유저 정보 받아와서 /profile/뒤에 아이디 붙임
수정: 사이드바는 /profile로 이동, 유저 페이지에서 로그인 여부에 따라 /profile/userID로 리다이렉팅