### PR TITLE
localstorage 동기화 문제해결

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -83,8 +83,14 @@ export class AuthController {
       },
     },
   })
-  getGuestId(@Res({ passthrough: true }) res: Response): { clientId: string } {
-    const clientId = uuidv4();
+  getGuestId(
+    @Req() req: Request & { cookies?: Record<string, string> },
+    @Res({ passthrough: true }) res: Response,
+  ): { clientId: string } {
+    // 기존 client_id가 있으면 재사용
+    const existingClientId = req.cookies?.client_id;
+    const clientId = existingClientId || uuidv4();
+
     const isProduction = this.configService.get<string>('NODE_ENV') === 'production';
 
     res.cookie('client_id', clientId, {

--- a/apps/frontend/src/providers/AuthProvider.tsx
+++ b/apps/frontend/src/providers/AuthProvider.tsx
@@ -1,9 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 
 import { useCurrentUserQuery } from '@/hooks/queries/authQueries';
-import { useSyncStepHistoryMutation } from '@/hooks/queries/progressQueries';
 import { useAuthActions } from '@/store/authStore';
-import { storageUtil } from '@/utils/storage';
 
 interface AuthProviderProps {
   children: React.ReactNode;
@@ -11,11 +9,9 @@ interface AuthProviderProps {
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const { setUser, clearAuth, setAuthReady } = useAuthActions();
-  const hasSynced = useRef(false);
   const hasRequestedGuestId = useRef(false);
 
   const { data } = useCurrentUserQuery();
-  const syncStepHistoryMutation = useSyncStepHistoryMutation();
 
   // 비로그인 사용자에게 client_id 발급
   const initGuestId = useCallback(async () => {
@@ -26,27 +22,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     await fetch('/api/auth/guest-id', { method: 'GET' });
   }, []);
 
-  // 로컬 기록 서버와 동기화
-  const syncLocalProgress = useCallback(async () => {
-    if (hasSynced.current) return;
-
-    const storage = storageUtil.get();
-    const stepIds = storage.solved_step_history;
-    if (stepIds.length === 0) return;
-
-    hasSynced.current = true;
-    try {
-      await syncStepHistoryMutation.mutateAsync(stepIds);
-      storageUtil.set({ ...storage, solved_step_history: [] });
-    } catch {
-      hasSynced.current = false;
-    }
-  }, []);
-
   useEffect(() => {
     const finalizeAuth = async () => {
       if (data) {
-        await syncLocalProgress();
         setUser(data);
       } else {
         await initGuestId();
@@ -59,7 +37,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       clearAuth();
       setAuthReady(true);
     });
-  }, [clearAuth, data, setAuthReady, setUser, syncLocalProgress, initGuestId]);
+  }, [clearAuth, data, setAuthReady, setUser, initGuestId]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 1h
- 실제 작업 시간: 1h

<br/>

## 📌 작업 요약
비로그인 사용자의 step 완료 데이터를 Redis 기반으로 통합하고, localStorage는 UI 표시용으로만 사용하도록 변경. client_id 재사용 로직 추가로 여러 step 데이터가 올바르게 누적되도록 수정. 
<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)
  1. AuthProvider.tsx 수정                                                                                                                                                                                
    - syncLocalProgress() 함수 제거 (localStorage 동기화 경로 제거)                                                                                                                                       
    - useSyncStepHistoryMutation import 제거                                                                                                                                                              
    - hasSynced useRef 제거                                                                                                                                                                               
    - 로그인 시 Redis 경로만 사용하도록 변경 (Auth Service에서 처리)                                                                                                                                      
  2. auth.controller.ts - getGuestId() 엔드포인트 수정                                                                                                                                                    
    - 기존 client_id 쿠키 확인 로직 추가                                                                                                                                                                  
    - 쿠키가 있으면 재사용, 없으면 새로 생성                                                                                                                                                              
    - 결과: 같은 사용자가 항상 동일한 clientId를 유지                                                                                                                                                     
  3. 동기화 경로 정리                                                                                                                                                                                     
    - 비로그인: localStorage + Redis 모두 저장 (UI용 + 동기화용)                                                                                                                                          
    - 로그인: Redis 데이터만 동기화, localStorage는 읽지 않음                                                                                                                                             
    - LearnContainer: localStorage로 비로그인 UI 표

<br/>

## 🚨 주요 고민 및 해결 과정

> 주요 고민이나 문제 해결 과정 공유

  ### 문제                                                                                                                                                                                                    
                                                                                                                                                                                                          
  Redis에 step_ids:{clientId} 키가 매번 다른 값으로 저장되어 여러 step 완료 시 마지막 step만 동기화되는 이슈 발생                                                                                         
                                                                                                                                                                                                          
  step_ids:6a9ed85d-ee26-439e-be7f-1489ce98fe55  ← step 1                                                                                                                                                 
  step_ids:ac3fa36c-33cb-4830-bedc-bc886868616c  ← step 2 (새로운 ID)                                                                                                                                     
  step_ids:36be4731-27f2-4dbe-9366-3a0af43dcd0c  ← step 3 (또 다른 ID)                                                                                                                                    
                                                                                                                                                                                                          
  ### 해결 과정                                                                                                                                                                                               
                                                                                                                                                                                                          
  1. Redis 저장 구조 확인 → 로직 정상 (배열에 누적됨)                                                                                                                                                     
  2. client_id 생성/관리 로직 확인 → getGuestId() 매번 새로운 UUID 생성 발견                                                                                                                              
  3. 해결: 기존 client_id 쿠키 확인 후 있으면 재사용하도록 변경  

<br/>

## 📑 참고 문서/ ADR

> 참고한 외부 문서, 레퍼런스, 기술 블로그, 공식 문서 등의 링크

<br/>

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 기존 게스트 식별자 재사용으로 반복 방문 사용자 경험 개선
  * 인증 프로세스에서 불필요한 동기화 로직 제거로 성능 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->