### PR TITLE
대기실 테스트 페이지 및 결과창 이동

### DIFF
--- a/apps/backend/src/battle/battle.controller.ts
+++ b/apps/backend/src/battle/battle.controller.ts
@@ -26,7 +26,7 @@ export class BattleController {
     const roomId = this.createRoomId();
     const inviteToken = this.createInviteToken();
 
-    const fieldSlug = body.fieldSlug ?? 'cs';
+    const fieldSlug = body.fieldSlug ?? 'fe';
     const maxPlayers = body.maxPlayers ?? 5;
     const timeLimitType = body.timeLimitType ?? 'recommended';
 

--- a/apps/backend/src/roadmap/roadmap.service.ts
+++ b/apps/backend/src/roadmap/roadmap.service.ts
@@ -23,11 +23,7 @@ import type { FieldRoadmapResponse } from './dto/field-roadmap.dto';
 import type { FieldUnitsResponse, StepSummary } from './dto/field-units.dto';
 import type { FirstUnitResponse, UnitSummary } from './dto/first-unit.dto';
 import type { QuizResponse } from './dto/quiz-list.dto';
-import type {
-  MatchingPair,
-  QuizSubmissionRequest,
-  QuizSubmissionResponse,
-} from './dto/quiz-submission.dto';
+import type { QuizSubmissionRequest, QuizSubmissionResponse } from './dto/quiz-submission.dto';
 import type { UnitOverviewResponse } from './dto/unit-overview.dto';
 import { CheckpointQuizPool, Field, Quiz, Step, Unit } from './entities';
 

--- a/apps/frontend/src/features/battle/types.ts
+++ b/apps/frontend/src/features/battle/types.ts
@@ -93,3 +93,12 @@ export interface BattleResultData {
   scoreDelta: number; // +10, -10 등 점수 변화량
   totalScore: number; // 합산된 최종 점수
 }
+
+/**
+ * 배틀 보상 정보
+ */
+export interface BattleReward {
+  participantId: string;
+  rewardType: 'diamond';
+  amount: number;
+}

--- a/apps/frontend/src/hooks/queries/battleQueries.ts
+++ b/apps/frontend/src/hooks/queries/battleQueries.ts
@@ -9,3 +9,12 @@ export const useCreateBattleRoomMutation = () =>
   useMutation({
     mutationFn: () => battleService.createBattleRoom(),
   });
+
+/**
+ * 배틀 방 참가 가능 여부 확인을 위한 뮤테이션 훅
+ */
+export const useJoinBattleRoomMutation = () =>
+  useMutation({
+    mutationFn: ({ inviteToken }: { inviteToken: string }) =>
+      battleService.joinBattleRoom(inviteToken),
+  });

--- a/apps/frontend/src/pages/battle/BattleResultPage.tsx
+++ b/apps/frontend/src/pages/battle/BattleResultPage.tsx
@@ -1,0 +1,71 @@
+import { css } from '@emotion/react';
+
+import { useBattleStore } from '@/store/battleStore';
+
+export const BattleResultPage = () => {
+  const { rankings, rewards } = useBattleStore();
+
+  return (
+    <div css={containerStyle}>
+      <h1 css={titleStyle}>배틀 결과</h1>
+
+      <section css={sectionStyle}>
+        <h2 css={sectionTitleStyle}>순위</h2>
+        {rankings.length === 0 ? (
+          <p>결과 데이터가 없습니다.</p>
+        ) : (
+          <ol css={listStyle}>
+            {rankings.map((ranking, index) => (
+              <li key={ranking.participantId}>
+                {index + 1}등 {ranking.displayName} - {ranking.score}점
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <section css={sectionStyle}>
+        <h2 css={sectionTitleStyle}>보상</h2>
+        {rewards.length === 0 ? (
+          <p>지급된 보상이 없습니다.</p>
+        ) : (
+          <ul css={listStyle}>
+            {rewards.map(reward => (
+              <li key={`${reward.participantId}-${reward.rewardType}`}>
+                {reward.participantId} : {reward.rewardType} {reward.amount}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+};
+
+const containerStyle = css`
+  width: 100%;
+  min-height: 100vh;
+  background: #ffffff;
+  color: #111827;
+  padding: 32px;
+`;
+
+const titleStyle = css`
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 24px;
+`;
+
+const sectionStyle = css`
+  margin-bottom: 24px;
+`;
+
+const sectionTitleStyle = css`
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 12px;
+`;
+
+const listStyle = css`
+  padding-left: 20px;
+`;

--- a/apps/frontend/src/pages/battle/BattleTestPage.tsx
+++ b/apps/frontend/src/pages/battle/BattleTestPage.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Loading } from '@/comp/Loading';
+import { useBattleSocket } from '@/feat/battle/hooks/useBattleSocket';
+import {
+  useCreateBattleRoomMutation,
+  useJoinBattleRoomMutation,
+} from '@/hooks/queries/battleQueries';
+import { useBattleStore } from '@/store/battleStore';
+
+export const BattleTestPage = () => {
+  const { joinRoom, socket } = useBattleSocket();
+  const { status, participants, roomId, actions } = useBattleStore();
+  const navigate = useNavigate();
+  const createBattleRoom = useCreateBattleRoomMutation();
+  const joinBattleRoom = useJoinBattleRoomMutation();
+  const [inviteToken, setInviteToken] = useState('');
+  const [isJoining, setIsJoining] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+
+  const handleCreateRoom = useCallback(async () => {
+    setIsCreating(true);
+    try {
+      const createdRoom = await createBattleRoom.mutateAsync();
+      setInviteToken(createdRoom.inviteToken);
+
+      const joinResponse = await joinBattleRoom.mutateAsync({
+        inviteToken: createdRoom.inviteToken,
+      });
+      if (!joinResponse.canJoin) {
+        return;
+      }
+
+      joinRoom(joinResponse.roomId, {});
+      actions.setBattleState({
+        roomId: joinResponse.roomId,
+        inviteToken: createdRoom.inviteToken,
+      });
+    } finally {
+      setIsCreating(false);
+    }
+  }, [createBattleRoom, joinBattleRoom, joinRoom, actions]);
+
+  const handleJoin = useCallback(async () => {
+    if (!inviteToken.trim()) {
+      return;
+    }
+
+    setIsJoining(true);
+    try {
+      const response = await joinBattleRoom.mutateAsync({ inviteToken });
+      if (!response.canJoin) {
+        return;
+      }
+
+      joinRoom(response.roomId, {});
+      actions.setBattleState({ roomId: response.roomId });
+    } finally {
+      setIsJoining(false);
+    }
+  }, [inviteToken, joinBattleRoom, joinRoom, actions]);
+
+  const handleStart = useCallback(() => {
+    if (!roomId) {
+      return;
+    }
+
+    socket?.emit('battle:start', { roomId });
+    navigate('/battle/quiz');
+  }, [socket, roomId, navigate]);
+
+  if (isJoining || isCreating) {
+    return <Loading />;
+  }
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>배틀 테스트 페이지</h1>
+
+      <div style={{ marginTop: 16 }}>
+        <button type="button" onClick={handleCreateRoom}>
+          방 생성
+        </button>
+      </div>
+
+      <div style={{ marginTop: 16 }}>
+        <input
+          type="text"
+          placeholder="inviteToken 입력"
+          value={inviteToken}
+          onChange={event => setInviteToken(event.target.value)}
+          style={{ width: 240, marginRight: 8 }}
+        />
+        <button type="button" onClick={handleJoin}>
+          방 참가
+        </button>
+      </div>
+
+      <div style={{ marginTop: 16 }}>
+        <p>현재 상태: {status ?? '없음'}</p>
+        <p>참여자 수: {participants.length}명</p>
+        <p>현재 방 ID: {roomId ?? '없음'}</p>
+        <p>초대 토큰: {inviteToken || '없음'}</p>
+      </div>
+
+      <button type="button" onClick={handleStart} style={{ marginTop: 12 }}>
+        배틀 시작
+      </button>
+
+      <button type="button" onClick={() => navigate('/battle/quiz')} style={{ marginTop: 8 }}>
+        퀴즈 화면 이동
+      </button>
+    </div>
+  );
+};

--- a/apps/frontend/src/router/index.tsx
+++ b/apps/frontend/src/router/index.tsx
@@ -28,6 +28,15 @@ const Leaderboard = lazy(() =>
   import('@/pages/Leaderboard').then(m => ({ default: m.Leaderboard })),
 );
 const Battle = lazy(() => import('@/pages/battle/Battle').then(m => ({ default: m.Battle })));
+const BattleTestPage = lazy(() =>
+  import('@/pages/battle/BattleTestPage').then(m => ({ default: m.BattleTestPage })),
+);
+const BattleQuizPage = lazy(() =>
+  import('@/pages/battle/BattleQuizPage').then(m => ({ default: m.BattleQuizPage })),
+);
+const BattleResultPage = lazy(() =>
+  import('@/pages/battle/BattleResultPage').then(m => ({ default: m.BattleResultPage })),
+);
 const Reports = lazy(() => import('@/pages/admin/Reports').then(m => ({ default: m.Reports })));
 const InitialFields = lazy(() =>
   import('@/pages/learn/InitialFields').then(m => ({ default: m.InitialFields })),
@@ -72,6 +81,8 @@ export const router = createBrowserRouter([
               { path: 'review-result', element: <QuizReviewResult /> },
             ],
           },
+          { path: 'battle/test', element: <BattleTestPage /> },
+          { path: 'battle/quiz', element: <BattleQuizPage /> },
         ],
       },
       {
@@ -86,6 +97,7 @@ export const router = createBrowserRouter([
           { path: 'unsubscribe', element: <Unsubscribe /> },
           { path: 'temp', element: <TempPage /> },
           { path: 'battle', element: <Battle /> },
+          { path: 'battle/result', element: <BattleResultPage /> },
         ],
       },
 

--- a/apps/frontend/src/store/battleStore.ts
+++ b/apps/frontend/src/store/battleStore.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import type {
   BattleParticipant,
   BattleQuizData,
+  BattleReward,
   BattleRoomSettings,
   BattleRoomStatus,
   Ranking,
@@ -28,6 +29,7 @@ interface BattleState {
   status: BattleRoomStatus | null;
   participants: BattleParticipant[];
   rankings: Ranking[];
+  rewards: BattleReward[];
 
   // 3. 퀴즈 진행 정보
   currentQuizIndex: number;
@@ -70,13 +72,14 @@ export const useBattleStore = create<BattleState>(set => ({
   status: null,
   participants: [],
   rankings: [],
+  rewards: [],
   currentQuizIndex: 0,
   totalQuizzes: 10,
   remainingSeconds: 0,
   currentQuiz: null,
   currentQuizId: 0,
   quizEndsAt: 0,
-  resultEndsAt: 0,
+  resultEndsAt: null,
   selectedAnswers: [],
   quizSolutions: [],
   questionStatuses: [],
@@ -128,6 +131,7 @@ export const useBattleStore = create<BattleState>(set => ({
         status: null,
         participants: [],
         rankings: [],
+        rewards: [],
         currentQuizIndex: 0,
         totalQuizzes: 10,
         remainingSeconds: 0,


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 30m
- 실제 작업 시간: 30m

<br/>

## 📌 작업 요약
- 머지 버그 수정
- 대기실 테스트 페이지 구현(이후 로직 확인 위함)
- 결과창 이동 이벤트 및 데이터 출력
<br/>

## 📝 작업 내용
<img width="489" height="289" alt="스크린샷 2026-01-29 오전 1 07 24" src="https://github.com/user-attachments/assets/01e4fb27-26b1-4e72-9bf5-b4da41a0017e" />


- 테스트페이지 주소: localhost:5173/battle/test
- 한 탭에서 테스트페이지 접속 후 방 생성 클릭(자동으로 방 참여됨)
- 다른 탭(시크릿탭)에서 테스트페이지 접속 후 방 생성 시 생성된 초대 토큰 입력 후 방 참가 클릭
- 방 생성을 한 탭에서 배틀 시작 클릭(자동시작됨)
- 다른 탭에서는 퀴즈화면 이동 클릭 

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 테스트 페이지는 나중에 삭제해야합니다!
- 정확하지 않은 로직으로 강제로 게임을 시작시키는거라 버그가 있을수있습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 배틀 완료 후 결과 페이지에서 순위와 보상을 표시하는 기능 추가
  * 초대 토큰을 사용하여 배틀 룸에 참여하는 기능 추가
  * 배틀 보상 시스템 도입 (다이아몬드 타입의 보상 지원)
  * 배틀 관련 새로운 탐색 경로 추가

* **리팩토링**
  * 배틀 퀴즈 결과 처리 로직 최적화
  * 불필요한 디버그 로그 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->