### PR TITLE
팔로잉/팔로워 알파벳 순 정렬

### DIFF
--- a/apps/backend/src/profile/profile.service.spec.ts
+++ b/apps/backend/src/profile/profile.service.spec.ts
@@ -163,4 +163,41 @@ describe('ProfileService', () => {
     expect(firstFollower.userId).toBe(10);
     expect(firstFollower.tier?.name).toBe('BRONZE');
   });
+
+  it('팔로워 목록을 영문 우선 이름순으로 정렬한다', async () => {
+    userFindOneMock.mockResolvedValue({ id: 1 } as User);
+    followFindMock.mockResolvedValue([
+      {
+        follower: {
+          id: 11,
+          displayName: '앨리스',
+          profileImageUrl: null,
+          experience: 300,
+          currentTier: { id: 1, name: 'BRONZE', orderIndex: 1 },
+        },
+      } as UserFollow,
+      {
+        follower: {
+          id: 12,
+          displayName: 'Zoe',
+          profileImageUrl: null,
+          experience: 220,
+          currentTier: { id: 2, name: 'SILVER', orderIndex: 2 },
+        },
+      } as UserFollow,
+      {
+        follower: {
+          id: 13,
+          displayName: 'Adam',
+          profileImageUrl: null,
+          experience: 180,
+          currentTier: { id: 3, name: 'GOLD', orderIndex: 3 },
+        },
+      } as UserFollow,
+    ]);
+
+    const result = await service.getFollowers(1);
+
+    expect(result.map(user => user.displayName)).toEqual(['Adam', 'Zoe', '앨리스']);
+  });
 });


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 10m
- 실제 작업 시간: 10m

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. 팔로워/팔로잉 목록을 이름 기준으로 정렬하도록 getFollowers, getFollowing 반환 처리 변경
2. 영문 → 한글 → 기타 순 정렬 규칙과 헬퍼 함수 추가
3. 영문 우선 정렬 테스트 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 팔로워 및 팔로잉 목록의 정렬 순서가 개선되었습니다. 이제 영어 이름이 먼저 알파벳 순으로 표시되고, 한국어 이름이 그 뒤에, 기타 언어가 마지막에 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->