### PR TITLE
배포 그라파나 경로 무한 리다이렉션 수정

### DIFF
--- a/docker/production/nginx/default.conf
+++ b/docker/production/nginx/default.conf
@@ -83,7 +83,8 @@ server {
     # -----------------------------------------------------
     location /grafana/ {
         # funda-grafana 컨테이너의 내부 포트(3000)로 연결
-        proxy_pass http://funda-grafana:3000/;
+        # 서브패스(/grafana/)를 유지하여 Grafana가 올바르게 인식하도록 함
+        proxy_pass http://funda-grafana:3000;
 
         # 그라파나 서브패스 인식을 위한 필수 헤더
         proxy_set_header Host $host;
@@ -97,5 +98,8 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
+
+        # 리다이렉션 루프 방지
+        proxy_redirect off;
     }
 }


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 5m
- 실제 작업 시간: 5m

<br/>

## 📝 작업 내용

- `default.conf`(nginx) 에서 `proxy_pass`의 trailing slash를 제거해 서브패스(`/grafana/`)를 그대로 Grafana로 전달하도록 했습니다.
- `proxy_redirect off;`도 추가해 리다이렉션 재작성으로 인한 루프를 막습니다.

<br/>

## 🚨 주요 고민 및 해결 과정

> 주요 고민이나 문제 해결 과정 공유

### 문제
https://funda.website/grafana/ 로 접속 시 브라우저에서 “funda.website에서 리디렉션한 횟수가 너무 많습니다.”가 뜹니다.

### 원인

- 현재 Nginx 설정에서 `/grafana/ `위치에 `proxy_pass http://funda-grafana:3000/;` (끝에 /)를 쓰고 있어서, 요청 URI가 `/grafana/` → 업스트림에선 `/`로 전달됩니다.
- Grafana는 `serve_from_sub_path=true` 상태라 `/`로 들어오면 다시 `/grafana/`로 리다이렉트합니다.
- 결과적으로 `/grafana/` → `/` → `/grafana/` → `/…` 무한 루프가 됩니다.

### 정리

- Grafana는 `/grafana/` 경로를 기대하고 있음
- Nginx가 `/grafana/`를 `/`로 바꿔 보내면 Grafana가 다시 `/grafana/`로 리다이렉트
- 그래서 무한 루프
- 이제 Nginx가 `/grafana/`를 그대로 전달하므로 루프 종료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션 환경의 Grafana 접근 설정을 개선했습니다.
  * 리다이렉트 루프 방지 메커니즘을 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->