### PR TITLE
퀴즈 페이지 진행 바 리셋 문제 해결

### DIFF
--- a/apps/frontend/src/features/quiz/components/QuizHeader.tsx
+++ b/apps/frontend/src/features/quiz/components/QuizHeader.tsx
@@ -62,7 +62,6 @@ export const QuizHeader = ({
   }, [navigate, leaveBattle, disconnect, roomId, isBattleMode]);
 
   const progress = (completedSteps / totalSteps) * 100;
-
   const displaySeconds = useCountdownTimer({ endsAt, remainingSeconds });
 
   return (

--- a/apps/frontend/src/hooks/queries/quizQueries.ts
+++ b/apps/frontend/src/hooks/queries/quizQueries.ts
@@ -17,6 +17,7 @@ export const useQuizzesByStepQuery = (
     queryKey: ['quizzes-by-step', stepId],
     queryFn: () => quizService.getQuizzesByStep(stepId),
     staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
     ...options,
   });
 

--- a/apps/frontend/src/pages/quiz/Quiz.tsx
+++ b/apps/frontend/src/pages/quiz/Quiz.tsx
@@ -223,22 +223,15 @@ export const Quiz = () => {
    * 퀴즈 데이터 가져오기
    */
   const fetchQuizzes = useCallback(() => {
-    if (!step_id && !isReviewMode) {
-      return;
-    }
-
-    if (!isAuthReady) {
-      return;
-    }
+    if (!step_id && !isReviewMode) return;
+    if (!isAuthReady) return;
 
     if (isReviewMode && !isLoggedIn) {
       navigate('/login');
       return;
     }
 
-    if (!quizzesData) {
-      return;
-    }
+    if (!quizzesData) return;
 
     if (quizzesData.length === 0) {
       setLoadError(true);
@@ -246,11 +239,20 @@ export const Quiz = () => {
     }
 
     setLoadError(false);
+
+    const shouldResetState =
+      quizzes.length === 0 ||
+      quizzesData.length !== quizzes.length ||
+      quizzesData.some((quiz, index) => quiz.id !== quizzes[index]?.id);
+
     setQuizzes(quizzesData);
-    setSelectedAnswers(new Array(quizzesData.length).fill(null));
-    setQuestionStatuses(new Array(quizzesData.length).fill('idle'));
-    setQuizSolutions(new Array(quizzesData.length).fill(null));
-  }, [step_id, isLoggedIn, isAuthReady, isReviewMode, navigate, quizzesData]);
+
+    if (shouldResetState) {
+      setSelectedAnswers(new Array(quizzesData.length).fill(null));
+      setQuestionStatuses(new Array(quizzesData.length).fill('idle'));
+      setQuizSolutions(new Array(quizzesData.length).fill(null));
+    }
+  }, [step_id, isLoggedIn, isAuthReady, isReviewMode, navigate, quizzesData, quizzes]);
 
   // -----------------------------------------------------------------------------
   // 네비게이션/이펙트


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 10m
- 실제 작업 시간: 10m

<br/>

## 📌 작업 요약

퀴즈 페이지 상단 헤더의 진행 바가 탭 복귀 후 0으로 리셋되던 문제 해결

<br/>

## 📝 작업 내용

1. Quiz.tsx에서 fetchQuizzes가 refetch될 때 `QuizSolutions`를 무조건 초기화하지 않도록, 퀴즈 리스트(id/길이)가 바뀐 경우에만 리셋하도록 수정했습니다.
2. `useQuizzesByStepQuery`에 r`efetchOnWindowFocus: false` 옵션을 추가해 탭 복귀 `refetch` 가 일어나지 않도록 방지하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 창 포커스 시 퀴즈 데이터의 불필요한 새로 고침 제거로 성능 최적화

* **버그 수정**
  * 퀴즈 상태 초기화 로직을 더욱 정확하게 개선하여 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->