### PR TITLE
refactor: 프로필 이미지를 user store에서 공통적으로 관리하도록 수정

### DIFF
--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -141,7 +141,10 @@ export class AuthService {
     tokenRecord.lastUsedAt = new Date();
     await this.refreshTokens.save(tokenRecord);
 
-    const user = await this.users.findOneBy({ id: userId });
+    const user = await this.users.findOne({
+      where: { id: userId },
+      relations: { profileCharacter: true },
+    });
     if (!user) {
       throw new UnauthorizedException('유저 정보를 찾을 수 없습니다.');
     }
@@ -381,7 +384,10 @@ export class AuthService {
    * ID로 유저를 조회한다.
    */
   async getUserById(userId: number): Promise<User | null> {
-    return this.users.findOneBy({ id: userId });
+    return this.users.findOne({
+      where: { id: userId },
+      relations: { profileCharacter: true },
+    });
   }
 
   /**
@@ -426,7 +432,7 @@ export class AuthService {
       id: user.id,
       displayName: user.displayName,
       email: user.email ?? null,
-      profileImageUrl: user.profileImageUrl ?? null,
+      profileImageUrl: user.profileCharacter?.imageUrl ?? user.profileImageUrl ?? null,
       role: user.role,
       heartCount: user.heartCount,
       maxHeartCount: user.maxHeartCount,

--- a/apps/backend/src/ranking/ranking-query.service.ts
+++ b/apps/backend/src/ranking/ranking-query.service.ts
@@ -119,7 +119,7 @@ export class RankingQueryService {
 
     const groupMembers = await this.memberRepository.find({
       where: { groupId: member.groupId },
-      relations: { user: true },
+      relations: { user: { profileCharacter: true } },
     });
     const memberIds = groupMembers.map(groupMember => groupMember.userId);
     const weeklyXpList = await this.weeklyXpRepository.find({
@@ -135,7 +135,8 @@ export class RankingQueryService {
       return {
         userId: groupMember.userId,
         displayName: groupMember.user?.displayName ?? '알 수 없음',
-        profileImageUrl: groupMember.user?.profileImageUrl ?? null,
+        profileImageUrl:
+          groupMember.user?.profileCharacter?.imageUrl ?? groupMember.user?.profileImageUrl ?? null,
         xp: weeklyXp?.xp ?? 0,
         lastSolvedAt,
       };
@@ -241,7 +242,7 @@ export class RankingQueryService {
 
     const groupMembers = await this.memberRepository.find({
       where: { groupId: group.id },
-      relations: { user: true },
+      relations: { user: { profileCharacter: true } },
     });
 
     if (groupMembers.length === 0) {
@@ -270,7 +271,8 @@ export class RankingQueryService {
       return {
         userId: groupMember.userId,
         displayName: groupMember.user?.displayName ?? '알 수 없음',
-        profileImageUrl: groupMember.user?.profileImageUrl ?? null,
+        profileImageUrl:
+          groupMember.user?.profileCharacter?.imageUrl ?? groupMember.user?.profileImageUrl ?? null,
         xp: weeklyXp?.xp ?? 0,
         lastSolvedAt,
       };

--- a/apps/frontend/src/layouts/Sidebar.tsx
+++ b/apps/frontend/src/layouts/Sidebar.tsx
@@ -8,8 +8,7 @@ import { Loading } from '@/components/Loading';
 import SVGIcon from '@/components/SVGIcon';
 import { useLogoutMutation } from '@/hooks/queries/authQueries';
 import { useRankingMe } from '@/hooks/queries/leaderboardQueries';
-import { useProfileSummary } from '@/hooks/queries/userQueries';
-import { useAuthUser, useIsLoggedIn } from '@/store/authStore';
+import { useAuthProfileImageUrl, useAuthUser, useIsLoggedIn } from '@/store/authStore';
 import { useModal } from '@/store/modalStore';
 import { useToast } from '@/store/toastStore';
 import type { Theme } from '@/styles/theme';
@@ -35,7 +34,7 @@ export const Sidebar = () => {
   const navigate = useNavigate();
   const isLoggedIn = useIsLoggedIn();
   const user = useAuthUser();
-  const userId = user?.id ?? null;
+  const profileImageUrl = useAuthProfileImageUrl();
 
   const { showToast } = useToast();
   const { confirm } = useModal();
@@ -44,8 +43,6 @@ export const Sidebar = () => {
   // 사용자 티어 조회
   const { data: rankingMe } = useRankingMe(isLoggedIn && !!user);
   const tierName = rankingMe?.tier?.name ?? null;
-  const { data: profileSummary } = useProfileSummary(userId);
-  const profileImageUrl = profileSummary?.profileImageUrl ?? user?.profileImageUrl ?? null;
 
   // 관리자 여부 확인
   const isAdmin = user?.role === 'admin';

--- a/apps/frontend/src/pages/battle/BattleSetupPage.tsx
+++ b/apps/frontend/src/pages/battle/BattleSetupPage.tsx
@@ -6,6 +6,7 @@ import { useBattleSocket } from '@/feat/battle/hooks/useBattleSocket';
 import type { Participant } from '@/feat/battle/types';
 import { BattleSetupContainer } from '@/features/battle/components/setup/BattleSetupContainer';
 import { useJoinBattleRoomQuery } from '@/hooks/queries/battleQueries';
+import { useAuthProfileImageUrl, useAuthUser } from '@/store/authStore';
 import { useToast } from '@/store/toastStore';
 
 function hashString(str: string): number {
@@ -22,6 +23,8 @@ export const BattleSetupPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { showToast } = useToast();
+  const authUser = useAuthUser();
+  const battleProfileImageUrl = useAuthProfileImageUrl() ?? undefined;
 
   if (!inviteToken) {
     throw new Error('inviteToken is required');
@@ -43,11 +46,21 @@ export const BattleSetupPage = () => {
       return;
     }
 
-    joinBattle(data.roomId, undefined, {
-      inviteToken,
-      settings: data.settings,
-    });
-  }, [data, inviteToken, joinBattle, navigate]);
+    joinBattle(
+      data.roomId,
+      authUser
+        ? {
+            userId: authUser.id,
+            displayName: authUser.displayName,
+            profileImageUrl: battleProfileImageUrl,
+          }
+        : undefined,
+      {
+        inviteToken,
+        settings: data.settings,
+      },
+    );
+  }, [authUser, battleProfileImageUrl, data, inviteToken, joinBattle, navigate]);
 
   useEffect(() => {
     if (!isError) {

--- a/apps/frontend/src/pages/user/Profile.tsx
+++ b/apps/frontend/src/pages/user/Profile.tsx
@@ -14,7 +14,12 @@ import {
   useProfileSummary,
   useUnfollowUserMutation,
 } from '@/hooks/queries/userQueries';
-import { useAuthUser, useIsAuthReady, useIsLoggedIn } from '@/store/authStore';
+import {
+  useAuthProfileImageUrl,
+  useAuthUser,
+  useIsAuthReady,
+  useIsLoggedIn,
+} from '@/store/authStore';
 import { useToast } from '@/store/toastStore';
 
 /**
@@ -26,6 +31,7 @@ import { useToast } from '@/store/toastStore';
 export const Profile = () => {
   const { userId } = useParams();
   const user = useAuthUser();
+  const authProfileImageUrl = useAuthProfileImageUrl();
   const navigate = useNavigate();
   const isLoggedIn = useIsLoggedIn();
   const isAuthReady = useIsAuthReady();
@@ -110,9 +116,14 @@ export const Profile = () => {
     );
   }
 
+  const resolvedProfileSummary =
+    isMyProfile && profileSummary
+      ? { ...profileSummary, profileImageUrl: authProfileImageUrl }
+      : profileSummary;
+
   return (
     <ProfileContainer
-      profileSummary={profileSummary ?? null}
+      profileSummary={resolvedProfileSummary ?? null}
       following={following ?? []}
       followers={followers ?? []}
       isFollowingLoading={isFollowingLoading}

--- a/apps/frontend/src/store/authStore.tsx
+++ b/apps/frontend/src/store/authStore.tsx
@@ -32,6 +32,8 @@ export const useAuthStore = create<AuthState>(set => ({
 }));
 
 export const useAuthUser = () => useAuthStore(state => state.user);
+export const useAuthProfileImageUrl = () =>
+  useAuthStore(state => state.user?.profileImageUrl ?? null);
 export const useIsLoggedIn = () => useAuthStore(state => state.isLoggedIn);
 export const useIsAuthReady = () => useAuthStore(state => state.isAuthReady);
 export const useAuthActions = () => useAuthStore(state => state.actions);


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 20m
- 실제 작업 시간: 20m

<br/>

## 📌 작업 요약
- 서버에서 캐릭터 우선 프로필 이미지 내려주도록 로직 통일
- auth store의 프로필 이미지 경로를 공통 소스로 사용하도록 리팩토링
- 배틀 대기실/사이드바/프로필에서 캐릭터 이미지가 일관되게 표시되도록 수정
<br/>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 프로필 이미지 로딩 방식을 최적화하여 앱 전반에서 더 일관되게 표시되도록 개선했습니다.
  * 사용자 프로필 데이터 조회 성능을 향상시켰습니다.
  * 애니메이션 설정, 순위 표시, 프로필 페이지에서 프로필 이미지 표시 로직을 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->