### PR TITLE
매칭 문제 ux 개선

### DIFF
--- a/apps/frontend/src/features/quiz/components/quizOptions/MatchingLine.tsx
+++ b/apps/frontend/src/features/quiz/components/quizOptions/MatchingLine.tsx
@@ -2,6 +2,8 @@ import { useLayoutEffect, useState } from 'react';
 
 import { palette } from '@/styles/token';
 
+type MatchingLineVariant = 'neutral' | 'correct' | 'wrong';
+
 interface MatchingLineProps {
   /** 시작점(좌측) 버튼의 DOM 요소 */
   startEl: HTMLButtonElement;
@@ -9,15 +11,27 @@ interface MatchingLineProps {
   endEl: HTMLButtonElement;
   /** 기준이 되는 부모 컨테이너 DOM 요소 */
   containerEl: HTMLDivElement;
-  /** 정답 여부에 따른 선의 색상 결정 */
-  isCorrect: boolean;
+  /** 선의 색상/스타일 결정 */
+  variant?: MatchingLineVariant;
 }
 
 /**
  * 두 선택지 사이의 연결선을 계산하여 SVG Line으로 렌더링
  */
-export const MatchingLine = ({ startEl, endEl, containerEl, isCorrect }: MatchingLineProps) => {
+export const MatchingLine = ({
+  startEl,
+  endEl,
+  containerEl,
+  variant = 'neutral',
+}: MatchingLineProps) => {
   const [coords, setCoords] = useState({ x1: 0, y1: 0, x2: 0, y2: 0 });
+  const strokeColor =
+    variant === 'correct'
+      ? palette.success.main
+      : variant === 'wrong'
+        ? palette.error.main
+        : palette.primary.light;
+  const dashArray = variant === 'wrong' ? '5,5' : '0';
 
   /** getBoundingClientRect를 사용하여 실시간 좌표를 계산 */
   useLayoutEffect(() => {
@@ -47,9 +61,9 @@ export const MatchingLine = ({ startEl, endEl, containerEl, isCorrect }: Matchin
       y1={coords.y1}
       x2={coords.x2}
       y2={coords.y2}
-      stroke={isCorrect ? palette.success.main : palette.error.main}
+      stroke={strokeColor}
       strokeWidth="2"
-      strokeDasharray={isCorrect ? '0' : '5,5'}
+      strokeDasharray={dashArray}
       style={{ transition: 'all 0.3s ease' }}
     />
   );

--- a/apps/frontend/src/features/quiz/components/quizType/QuizMatching.tsx
+++ b/apps/frontend/src/features/quiz/components/quizType/QuizMatching.tsx
@@ -192,9 +192,11 @@ export const QuizMatching = ({
   );
 
   // 리사이즈 감지 및 SVG 라인 재계산
+  const shouldObserveLines = showResult || currentPairs.length > 0;
+
   useEffect(() => {
     isMountedRef.current = true;
-    if (!showResult || !containerRef.current) return;
+    if (!shouldObserveLines || !containerRef.current) return;
 
     // ResizeObserver가 사용 가능한지 확인
     if (typeof ResizeObserver === 'undefined') return;
@@ -218,12 +220,33 @@ export const QuizMatching = ({
       isMountedRef.current = false;
       resizeObserver.disconnect();
     };
-  }, [showResult, currentPairs.length]);
+  }, [showResult, currentPairs.length, shouldObserveLines]);
 
   return (
     <div css={matchingWrapperStyle} ref={containerRef}>
       {renderColumn('left')}
       {renderColumn('right')}
+
+      {!showResult && currentPairs.length > 0 && (
+        <svg css={svgOverlayStyle} key={`user-${lineUpdateTrigger}`}>
+          {currentPairs.map((pair, index) => {
+            const startEl = optionRefs.current.get(`left-${pair.left}`);
+            const endEl = optionRefs.current.get(`right-${pair.right}`);
+
+            if (!startEl || !endEl || !containerRef.current) return null;
+
+            return (
+              <MatchingLine
+                key={`${pair.left}-${pair.right}-${index}`}
+                startEl={startEl}
+                endEl={endEl}
+                containerEl={containerRef.current}
+                variant="neutral"
+              />
+            );
+          })}
+        </svg>
+      )}
 
       {showResult && correctPairs.length > 0 && (
         <svg css={svgOverlayStyle} key={lineUpdateTrigger}>
@@ -244,7 +267,7 @@ export const QuizMatching = ({
                 startEl={startEl}
                 endEl={endEl}
                 containerEl={containerRef.current}
-                isCorrect={isUserCorrect}
+                variant={isUserCorrect ? 'correct' : 'wrong'}
               />
             );
           })}


### PR DESCRIPTION
- related to #63

## ⏱ 소요 시간

- 예상 소요 시간: 10m
- 실제 작업 시간: 10m

<br/>

## 📝 작업 내용

<img width="1247" height="1079" alt="image" src="https://github.com/user-attachments/assets/1b14faf7-e19d-4222-9383-3915920ac74e" />

1. 제출 전(showResult false)에도 currentPairs 기준으로 연결선을 렌더링
2. 결과 화면은 기존대로 정답/오답 컬러 유지
3. 연결선 색상 제어를 위해 MatchingLine에 variant 추가

<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 퀴즈의 매칭 문제에서 선택 항목 간의 연결선 표시가 개선되었습니다. 이제 연결선이 올바른 답(녹색 실선), 오답(빨간색 점선), 아직 선택하지 않은 상태(기본색 실선)를 색상과 스타일로 명확하게 구분하여 표시합니다. 사용자는 자신의 답변 상태를 더욱 직관적으로 파악하고 더 나은 시각적 피드백을 받을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->