### PR TITLE
프로필 캐릭터 설정 페이지 ux 개선

### DIFF
--- a/apps/frontend/src/features/user/profile-character/ProfileCharacterContainer.tsx
+++ b/apps/frontend/src/features/user/profile-character/ProfileCharacterContainer.tsx
@@ -11,6 +11,8 @@ import { palette } from '@/styles/token';
 interface ProfileCharacterContainerProps {
   characters: ProfileCharacterItem[];
   selectedCharacterId: number | null;
+  activeCharacterId?: number | null;
+  activeCharacterImageUrl?: string | null;
   isLoading?: boolean;
   onSelect: (characterId: number) => void;
   onPurchase: (characterId: number) => void;
@@ -25,6 +27,8 @@ interface ProfileCharacterContainerProps {
 export const ProfileCharacterContainer = ({
   characters,
   selectedCharacterId,
+  activeCharacterId = null,
+  activeCharacterImageUrl = null,
   isLoading = false,
   onSelect,
   onPurchase,
@@ -45,13 +49,8 @@ export const ProfileCharacterContainer = ({
     event: MouseEvent<HTMLButtonElement>,
     character: ProfileCharacterItem,
   ) => {
-    if (!character.description) {
-      return;
-    }
-
-    if (!gridRef.current) {
-      return;
-    }
+    if (!character.description) return;
+    if (!gridRef.current) return;
 
     const rect = gridRef.current.getBoundingClientRect();
     setHoveredCharacter({
@@ -87,10 +86,24 @@ export const ProfileCharacterContainer = ({
           ) : (
             characters.map(item => {
               const isSelected = item.id === selectedCharacterId;
+              const isActiveCharacter =
+                (activeCharacterId !== null && item.id === activeCharacterId) ||
+                (!!activeCharacterImageUrl && item.imageUrl === activeCharacterImageUrl);
               const shouldShowAction = isSelected;
-              const actionLabel = item.isOwned ? '적용하기' : '구매하기';
+              const actionLabel = item.isOwned
+                ? isActiveCharacter
+                  ? '적용됨'
+                  : '적용하기'
+                : '구매하기';
+              const isActionDisabled = item.isOwned ? isActiveCharacter : false;
+              const actionVariant = item.isOwned
+                ? isActiveCharacter
+                  ? 'applied'
+                  : 'apply'
+                : 'purchase';
 
               const handleActionClick = () => {
+                if (isActionDisabled) return;
                 if (item.isOwned) {
                   onApply(item.id);
                   return;
@@ -113,7 +126,9 @@ export const ProfileCharacterContainer = ({
                       <img src={item.imageUrl} alt="캐릭터 이미지" css={imageStyle} />
                     </div>
                     <div css={priceStyle(theme)}>
-                      {item.isOwned ? (
+                      {isActiveCharacter ? (
+                        <span css={appliedLabelStyle(theme)}>적용됨</span>
+                      ) : item.isOwned ? (
                         <span css={purchasedLabelStyle(theme)}>구매함</span>
                       ) : item.priceDiamonds === 0 ? (
                         <span css={freeLabelStyle}>FREE</span>
@@ -129,8 +144,9 @@ export const ProfileCharacterContainer = ({
                     <div css={actionWrapperStyle}>
                       <button
                         type="button"
-                        css={actionCardStyle(theme)}
+                        css={actionCardStyle(theme, actionVariant)}
                         onClick={handleActionClick}
+                        disabled={isActionDisabled}
                       >
                         {actionLabel}
                       </button>
@@ -159,7 +175,7 @@ export const ProfileCharacterContainer = ({
 const pageStyle = (theme: Theme) => css`
   flex: 1;
   min-height: 100vh;
-  padding: 2rem 1.5rem 7.5rem;
+  padding: 2rem 1.5rem 0;
   background: ${theme.colors.surface.default};
 `;
 
@@ -313,7 +329,19 @@ const freeLabelStyle = css`
 `;
 
 const purchasedLabelStyle = (theme: Theme) => css`
-  color: ${theme.colors.text.weak};
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: ${theme.colors.surface.strong};
+  color: ${theme.colors.text.default};
+  font-weight: ${theme.typography['12Bold'].fontWeight};
+  border: 1px solid ${theme.colors.border.default};
+`;
+
+const appliedLabelStyle = (theme: Theme) => css`
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: ${theme.colors.primary.main};
+  color: ${theme.colors.grayscale[50]};
   font-weight: ${theme.typography['12Bold'].fontWeight};
 `;
 
@@ -324,7 +352,7 @@ const actionWrapperStyle = css`
   position: relative;
 `;
 
-const actionCardStyle = (theme: Theme) => css`
+const actionCardStyle = (theme: Theme, variant: 'apply' | 'purchase' | 'applied') => css`
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -332,14 +360,14 @@ const actionCardStyle = (theme: Theme) => css`
   padding: 12px 24px;
   border: none;
   border-radius: ${theme.borderRadius.medium};
-  background: ${theme.colors.primary.main};
+  background: ${variant === 'purchase' ? theme.colors.primary.main : theme.colors.text.weak};
   color: ${theme.colors.grayscale[50]};
   font-size: ${theme.typography['16Bold'].fontSize};
   font-weight: ${theme.typography['16Bold'].fontWeight};
   line-height: ${theme.typography['16Bold'].lineHeight};
   cursor: pointer;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 12px rgba(101, 89, 234, 0.25);
+  box-shadow: ${variant === 'purchase' ? '0 4px 12px rgba(101, 89, 234, 0.25)' : 'none'};
   position: relative;
 
   &::before {
@@ -352,13 +380,14 @@ const actionCardStyle = (theme: Theme) => css`
     height: 0;
     border-left: 8px solid transparent;
     border-right: 8px solid transparent;
-    border-bottom: 10px solid ${theme.colors.primary.main};
+    border-bottom: 10px solid
+      ${variant === 'purchase' ? theme.colors.primary.main : theme.colors.text.default};
   }
 
   &:hover {
-    background: ${theme.colors.primary.dark};
+    background: ${variant === 'purchase' ? theme.colors.primary.dark : theme.colors.text.default};
     transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(101, 89, 234, 0.35);
+    box-shadow: ${variant === 'purchase' ? '0 6px 16px rgba(101, 89, 234, 0.35)' : 'none'};
   }
 
   &:active {

--- a/apps/frontend/src/features/user/profile-character/test/ProfileCharacterContainer.test.tsx
+++ b/apps/frontend/src/features/user/profile-character/test/ProfileCharacterContainer.test.tsx
@@ -10,7 +10,13 @@ vi.mock('@/comp/SVGIcon', () => ({
   default: () => <span data-testid="svg-icon" />,
 }));
 
-const TestWrapper = () => {
+const TestWrapper = ({
+  activeCharacterId,
+  activeCharacterImageUrl,
+}: {
+  activeCharacterId?: number | null;
+  activeCharacterImageUrl?: string | null;
+}) => {
   const [selectedId, setSelectedId] = useState<number | null>(null);
   return (
     <ThemeProvider theme={lightTheme}>
@@ -21,7 +27,7 @@ const TestWrapper = () => {
             imageUrl: 'https://placehold.co/140x140?text=01',
             priceDiamonds: 1,
             description: '첫 번째 캐릭터 설명입니다.',
-            isActive: true,
+            isActive: false,
             isOwned: false,
           },
           {
@@ -34,6 +40,8 @@ const TestWrapper = () => {
           },
         ]}
         selectedCharacterId={selectedId}
+        activeCharacterId={activeCharacterId}
+        activeCharacterImageUrl={activeCharacterImageUrl}
         onSelect={setSelectedId}
         onPurchase={vi.fn()}
         onApply={vi.fn()}
@@ -72,5 +80,16 @@ describe('ProfileCharacterContainer', () => {
     fireEvent.mouseEnter(characterCard, { clientX: 120, clientY: 80 });
 
     expect(screen.getByText('첫 번째 캐릭터 설명입니다.')).toBeInTheDocument();
+  });
+
+  it('현재 적용된 캐릭터는 적용됨이 표시되고 적용 버튼이 비활성화된다', () => {
+    render(<TestWrapper activeCharacterId={2} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '캐릭터 2 선택' }));
+
+    const actionButton = screen.getByRole('button', { name: '적용됨' });
+
+    expect(actionButton).toBeDisabled();
+    expect(screen.getByText('적용됨')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 30m
- 실제 작업 시간: 10m

<br/>

## 📌 작업 요약

프로필 사진으로 적용됨 / 적용하기 / 구매하기로 디테일한 조건 분기 및 ui 반영

<br/>

## 📝 작업 내용

https://github.com/user-attachments/assets/a815db82-2a7c-4aa6-8de3-e30c4c2a68c2

1. 유저 정보 quries로 받아와서 현재 적용된 프로필 버튼 비활성화 및 밝은 회색 처리
2. 프로필 이미지를 즉시 반영되게 수정하여 적용됨, 적용하기, 구매하기 ui 분기 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 활성 캐릭터 상태 표시 기능 추가
  * 캐릭터 버튼 상태 구분: "적용됨", "적용하기", "구매하기"
  * 활성 캐릭터 중복 적용 방지를 위한 버튼 비활성화

* **Tests**
  * 활성 캐릭터 상태 감지 및 버튼 상태 검증 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->