### PR TITLE
fix: 팔로잉 팔로워 목록 모달 하단 잘림 방지

### DIFF
--- a/apps/frontend/src/features/user/profile/components/FollowListModal.tsx
+++ b/apps/frontend/src/features/user/profile/components/FollowListModal.tsx
@@ -34,7 +34,7 @@ export const FollowListModal = ({
     activeTab === 'following' ? '팔로잉한 사용자가 없습니다.' : '팔로워가 없습니다.';
 
   return (
-    <div css={containerStyle(theme)}>
+    <div css={containerStyle} role="dialog" aria-label="팔로잉/팔로워 목록">
       <div css={tabRowStyle(theme, activeTab)}>
         <button
           type="button"
@@ -51,7 +51,7 @@ export const FollowListModal = ({
           팔로워 {followerCount}
         </button>
       </div>
-      <div css={listWrapperStyle()}>
+      <div css={listWrapperStyle}>
         {isLoading && <p css={emptyTextStyle(theme)}>로딩 중...</p>}
         {!isLoading && list.length === 0 && <p css={emptyTextStyle(theme)}>{emptyText}</p>}
         {!isLoading &&
@@ -85,12 +85,10 @@ export const FollowListModal = ({
   );
 };
 
-const containerStyle = (theme: Theme) => css`
+const containerStyle = css`
+  height: 65vh;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  color: ${theme.colors.text.default};
-  min-height: 420px;
 `;
 
 const tabRowStyle = (theme: Theme, activeTab: 'following' | 'followers') => css`
@@ -120,15 +118,13 @@ const tabStyle = (theme: Theme, isActive: boolean) => css`
   color: ${isActive ? theme.colors.primary.main : theme.colors.text.light};
 `;
 
-const listWrapperStyle = () => css`
+const listWrapperStyle = css`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  min-height: 320px;
-  max-height: 480px;
   flex: 1;
+  padding-top: 16px;
   overflow-y: auto;
-  padding-right: 4px;
 `;
 
 const listItemStyle = (theme: Theme) => css`


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 20m
- 실제 작업 시간: 40m

<br/>

## 📝 작업 내용

### AS-IS

<img width="1210" height="866" alt="image" src="https://github.com/user-attachments/assets/4a8e17d9-a636-45b1-a9b6-95843707b91f" />

### TO-BE

<img width="1191" height="732" alt="image" src="https://github.com/user-attachments/assets/09360d86-2e00-4014-b092-5fdc5a136496" />

1. 모달 높이가 일정 높이 이하로 줄어들면 스크롤이 보이지 않고 맨 끝까지 내려가지 않는 현상을 발견했습니다.
2. 모달 높이를 viewport 기준으로 맞춰 높이와 상관없이 아래 공간이 남고, 끝까지 스크롤 가능하도록 수정하였습니다.

---

실제 작업은 오래 걸리지 않았는데 갑자기 wsl에서 storybook 이 안 나와서...,....
스토리북으로 버그를 수정하려다 잘 안돼서 결국 로컬 db에 더미 유저 넣어서 수정했습니다..ㅎㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 팔로우/팔로워 목록 모달의 접근성을 개선했습니다.
  * 모달의 UI 스타일을 개선하여 더 나은 사용자 경험을 제공합니다.
  * 목록 스크롤 동작을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->