### PR TITLE
boostAd 레이아웃 수정

### DIFF
--- a/apps/frontend/src/features/learn/components/RightSidebar.tsx
+++ b/apps/frontend/src/features/learn/components/RightSidebar.tsx
@@ -354,8 +354,6 @@ export const LearnRightSidebar = ({
             </Button>
           </div>
 
-          <div data-boostad-zone css={[cardStyle(theme), boostadZoneOverride]}></div>
-
           {!isLoggedIn && !user && (
             <div css={overlayStyle(theme)}>
               <div css={overlayHeaderStyle}>
@@ -372,6 +370,8 @@ export const LearnRightSidebar = ({
             </div>
           )}
         </div>
+
+        <div data-boostad-zone css={[cardStyle(theme), boostadZoneOverride]}></div>
 
         {isSearchModalOpen && (
           <Modal
@@ -630,7 +630,7 @@ const progressBarStyle = (theme: Theme, percentage: number) => css`
 
 const boostadZoneOverride = css`
   &[data-boostad-zone] {
-    margin: 0 !important;
+    margin: 24px 0 0 !important;
   }
 
   min-height: 107px;


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 5m
- 실제 작업 시간: 5m

<br/>

## 📝 작업 내용

미리보기 레이아웃에서 분리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **스타일**
  * 오른쪽 사이드바의 광고 영역 위치를 조정하고 상단 여백을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->