### PR TITLE
주간 랭킹 정산 로직 메서드 분리 리팩토링

### DIFF
--- a/apps/backend/src/ranking/ranking-evaluation.service.spec.ts
+++ b/apps/backend/src/ranking/ranking-evaluation.service.spec.ts
@@ -171,7 +171,19 @@ describe('RankingEvaluationService', () => {
     expect(snapshotRepository.save).not.toHaveBeenCalled();
   });
 
-  it('정상 평가는 보상을 원자적으로 지급하고 평가 완료로 확정한다', async () => {
+  it('티어 룰이 없으면 평가를 중단하고 확정하지 않는다', async () => {
+    const week = { id: 1, status: RankingWeekStatus.OPEN } as RankingWeek;
+    (weekRepository.findOne as jest.Mock).mockResolvedValue(week);
+    (tierRepository.find as jest.Mock).mockResolvedValue([bronzeTier]);
+    (ruleRepository.find as jest.Mock).mockResolvedValue([]);
+
+    await expect(service.evaluateWeek(1)).rejects.toThrow('티어 룰셋이 없습니다');
+
+    expect(week.status).not.toBe(RankingWeekStatus.EVALUATED);
+    expect(userRepository.increment).not.toHaveBeenCalled();
+  });
+
+  it('보상과 완료 상태를 같은 트랜잭션 콜백에서 처리한다', async () => {
     const week = { id: 1, status: RankingWeekStatus.OPEN } as RankingWeek;
     setupHappyPath(week);
 
@@ -185,7 +197,7 @@ describe('RankingEvaluationService', () => {
     expect(week.evaluatedAt).toBeDefined();
   });
 
-  it('같은 주차를 두 번 평가해도 보상은 한 번만 지급된다 (재실행 멱등성)', async () => {
+  it('평가 완료 상태인 순차 재호출을 차단한다', async () => {
     const week = { id: 1, status: RankingWeekStatus.OPEN } as RankingWeek;
     setupHappyPath(week);
 

--- a/apps/backend/src/ranking/ranking-evaluation.service.spec.ts
+++ b/apps/backend/src/ranking/ranking-evaluation.service.spec.ts
@@ -1,0 +1,198 @@
+import { DataSource, EntityManager, Repository } from 'typeorm';
+
+import { User } from '../users/entities/user.entity';
+
+import { RankingGroup } from './entities/ranking-group.entity';
+import { RankingGroupMember } from './entities/ranking-group-member.entity';
+import { RankingRewardHistory } from './entities/ranking-reward-history.entity';
+import { RankingTier } from './entities/ranking-tier.entity';
+import { RankingTierName } from './entities/ranking-tier.enum';
+import { RankingTierChangeHistory } from './entities/ranking-tier-change-history.entity';
+import { RankingTierRule } from './entities/ranking-tier-rule.entity';
+import { RankingWeek } from './entities/ranking-week.entity';
+import { RankingWeekStatus } from './entities/ranking-week-status.enum';
+import { RankingWeeklySnapshot } from './entities/ranking-weekly-snapshot.entity';
+import { RankingWeeklyXp } from './entities/ranking-weekly-xp.entity';
+import { RankingEvaluationService } from './ranking-evaluation.service';
+
+describe('RankingEvaluationService', () => {
+  let service: RankingEvaluationService;
+  let dataSource: Partial<DataSource>;
+  let weekRepository: Partial<Repository<RankingWeek>>;
+  let tierRepository: Partial<Repository<RankingTier>>;
+  let ruleRepository: Partial<Repository<RankingTierRule>>;
+  let groupRepository: Partial<Repository<RankingGroup>>;
+  let memberRepository: Partial<Repository<RankingGroupMember>>;
+  let weeklyXpRepository: Partial<Repository<RankingWeeklyXp>>;
+  let snapshotRepository: Partial<Repository<RankingWeeklySnapshot>>;
+  let tierChangeRepository: Partial<Repository<RankingTierChangeHistory>>;
+  let rewardRepository: Partial<Repository<RankingRewardHistory>>;
+  let userRepository: Partial<Repository<User>>;
+
+  // 브론즈 1명이 승급해 다이아 보상을 받는 최소 시나리오를 구성한다.
+  const bronzeTier = { id: 10, name: RankingTierName.BRONZE, orderIndex: 1 } as RankingTier;
+  const silverTier = { id: 11, name: RankingTierName.SILVER, orderIndex: 2 } as RankingTier;
+  const bronzeRule = {
+    tierId: 10,
+    isMaster: false,
+    promoteRatio: '1',
+    demoteRatio: '0',
+    promoteMinXp: 0,
+    demoteMinXp: 0,
+  } as RankingTierRule;
+  const silverRule = {
+    tierId: 11,
+    isMaster: true,
+    promoteRatio: '0',
+    demoteRatio: '0',
+    promoteMinXp: 0,
+    demoteMinXp: 0,
+  } as RankingTierRule;
+
+  const setupHappyPath = (week: RankingWeek): void => {
+    const group = {
+      id: 100,
+      weekId: week.id,
+      tierId: bronzeTier.id,
+      groupIndex: 1,
+    } as RankingGroup;
+    const solvedAt = new Date('2025-01-06T00:00:00Z');
+    const member = { userId: 5, joinedAt: solvedAt } as RankingGroupMember;
+    const weeklyXp = {
+      userId: 5,
+      xp: 100,
+      lastSolvedAt: solvedAt,
+      firstSolvedAt: solvedAt,
+    } as RankingWeeklyXp;
+
+    (weekRepository.findOne as jest.Mock).mockResolvedValue(week);
+    (tierRepository.find as jest.Mock).mockResolvedValue([bronzeTier, silverTier]);
+    (ruleRepository.find as jest.Mock).mockResolvedValue([bronzeRule, silverRule]);
+    (groupRepository.find as jest.Mock).mockImplementation(
+      (options: { where: { tierId: number } }) =>
+        options.where.tierId === bronzeTier.id ? [group] : [],
+    );
+    (memberRepository.find as jest.Mock).mockResolvedValue([member]);
+    (weeklyXpRepository.find as jest.Mock).mockResolvedValue([weeklyXp]);
+  };
+
+  beforeEach(() => {
+    weekRepository = { findOne: jest.fn(), save: jest.fn() };
+    tierRepository = { find: jest.fn().mockResolvedValue([]) };
+    ruleRepository = { find: jest.fn().mockResolvedValue([]) };
+    groupRepository = { find: jest.fn().mockResolvedValue([]) };
+    memberRepository = { find: jest.fn().mockResolvedValue([]) };
+    weeklyXpRepository = { find: jest.fn().mockResolvedValue([]) };
+    snapshotRepository = {
+      create: jest.fn(entity => entity),
+      save: jest.fn(),
+    } as unknown as Partial<Repository<RankingWeeklySnapshot>>;
+    tierChangeRepository = {
+      create: jest.fn(entity => entity),
+      save: jest.fn(),
+    } as unknown as Partial<Repository<RankingTierChangeHistory>>;
+    rewardRepository = { create: jest.fn(entity => entity), save: jest.fn() } as unknown as Partial<
+      Repository<RankingRewardHistory>
+    >;
+    userRepository = { increment: jest.fn(), update: jest.fn() };
+
+    const getRepository = jest.fn(entity => {
+      switch (entity) {
+        case RankingWeek:
+          return weekRepository;
+        case RankingTier:
+          return tierRepository;
+        case RankingTierRule:
+          return ruleRepository;
+        case RankingGroup:
+          return groupRepository;
+        case RankingGroupMember:
+          return memberRepository;
+        case RankingWeeklyXp:
+          return weeklyXpRepository;
+        case RankingWeeklySnapshot:
+          return snapshotRepository;
+        case RankingTierChangeHistory:
+          return tierChangeRepository;
+        case RankingRewardHistory:
+          return rewardRepository;
+        case User:
+          return userRepository;
+        default:
+          throw new Error('알 수 없는 Repository 요청');
+      }
+    });
+
+    const manager = { getRepository } as unknown as EntityManager;
+
+    dataSource = {
+      transaction: jest.fn(async (...args: unknown[]) => {
+        const callback = typeof args[0] === 'function' ? args[0] : args[1];
+        if (typeof callback !== 'function') {
+          throw new Error('transaction 콜백이 없습니다.');
+        }
+        return callback(manager);
+      }),
+    };
+
+    service = new RankingEvaluationService(dataSource as DataSource);
+  });
+
+  it('비관적 쓰기 락으로 주차를 조회한다', async () => {
+    const week = { id: 1, status: RankingWeekStatus.EVALUATED } as RankingWeek;
+    (weekRepository.findOne as jest.Mock).mockResolvedValue(week);
+
+    await service.evaluateWeek(1);
+
+    expect(weekRepository.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({ lock: { mode: 'pessimistic_write' } }),
+    );
+  });
+
+  it('존재하지 않는 주차는 아무 작업도 하지 않는다', async () => {
+    (weekRepository.findOne as jest.Mock).mockResolvedValue(null);
+
+    await service.evaluateWeek(999);
+
+    expect(weekRepository.save).not.toHaveBeenCalled();
+    expect(userRepository.increment).not.toHaveBeenCalled();
+    expect(snapshotRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('이미 평가된 주차는 다시 평가하지 않는다 (멱등 가드)', async () => {
+    const week = { id: 1, status: RankingWeekStatus.EVALUATED } as RankingWeek;
+    (weekRepository.findOne as jest.Mock).mockResolvedValue(week);
+
+    await service.evaluateWeek(1);
+
+    // 상태 전이도, 지급도 일어나지 않아야 한다.
+    expect(weekRepository.save).not.toHaveBeenCalled();
+    expect(userRepository.increment).not.toHaveBeenCalled();
+    expect(snapshotRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('정상 평가는 보상을 원자적으로 지급하고 평가 완료로 확정한다', async () => {
+    const week = { id: 1, status: RankingWeekStatus.OPEN } as RankingWeek;
+    setupHappyPath(week);
+
+    await service.evaluateWeek(1);
+
+    // 승급자에게 다이아를 increment로 적립한다.
+    expect(userRepository.increment).toHaveBeenCalledTimes(1);
+    expect(userRepository.increment).toHaveBeenCalledWith({ id: 5 }, 'diamondCount', 10);
+    // 주차를 평가 완료로 확정한다.
+    expect(week.status).toBe(RankingWeekStatus.EVALUATED);
+    expect(week.evaluatedAt).toBeDefined();
+  });
+
+  it('같은 주차를 두 번 평가해도 보상은 한 번만 지급된다 (재실행 멱등성)', async () => {
+    const week = { id: 1, status: RankingWeekStatus.OPEN } as RankingWeek;
+    setupHappyPath(week);
+
+    await service.evaluateWeek(1);
+    // 첫 평가로 week.status가 EVALUATED가 됐으므로, 두 번째 호출은 멱등 가드에 걸린다.
+    await service.evaluateWeek(1);
+
+    expect(userRepository.increment).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/ranking/ranking-evaluation.service.ts
+++ b/apps/backend/src/ranking/ranking-evaluation.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { InjectDataSource } from '@nestjs/typeorm';
-import { DataSource, In, LessThanOrEqual } from 'typeorm';
+import { DataSource, EntityManager, In, LessThanOrEqual } from 'typeorm';
 
 import { getKstNow } from '../common/utils/kst-date';
 import { User } from '../users/entities/user.entity';
@@ -22,6 +22,15 @@ import { RankingWeeklySnapshot } from './entities/ranking-weekly-snapshot.entity
 import { RankingWeeklyXp } from './entities/ranking-weekly-xp.entity';
 import { buildRankingSnapshots, resolveTierChange } from './ranking-evaluation.utils';
 
+// 한 주차 평가 결과를 모아 두는 중간 타입
+interface WeekEvaluationResult {
+  snapshots: RankingWeeklySnapshot[];
+  tierChanges: RankingTierChangeHistory[];
+  rewardHistories: RankingRewardHistory[];
+  tierUpdates: Array<{ userId: number; tierId: number }>;
+  rewardAmountByUser: Map<number, number>;
+}
+
 @Injectable()
 export class RankingEvaluationService {
   private readonly logger = new Logger(RankingEvaluationService.name);
@@ -34,19 +43,15 @@ export class RankingEvaluationService {
     [6, 100],
   ]);
 
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
   private getPromotionRewardAmount(tier: RankingTier): number {
     // 보상 수량이 확정되기 전까지는 임시 정책을 사용한다.
     return this.promotionRewardByTierOrder.get(tier.orderIndex) ?? 0;
   }
 
-  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
-
-  /**
-   * 매주 월요일 00:05(KST)에 주간 평가 스냅샷을 생성한다.
-   * - 종료된 주차 중 평가되지 않은 데이터만 처리한다.
-   *
-   * @returns {Promise<void>} 작업 완료
-   */
+  // 매주 월요일 00:05(KST), 종료됐지만 아직 평가 안 된 주차를 처리한다.
+  // 한 주차가 실패해도 나머지는 계속 평가한다.
   @Cron('5 0 * * 1', { timeZone: 'Asia/Seoul' })
   async handleWeeklyEvaluation(): Promise<void> {
     const now = getKstNow();
@@ -72,92 +77,114 @@ export class RankingEvaluationService {
     }
   }
 
-  /**
-   * 특정 주차의 랭킹 스냅샷을 생성한다.
-   *
-   * @param weekId 평가 대상 주차 ID
-   * @returns {Promise<void>} 작업 완료
-   */
+  // 한 주차를 평가하고 보상을 지급한다.
+  // 락과 평가 완료 상태 검사로 같은 주차가 중복 처리되지 않게 한 트랜잭션으로 묶는다.
   async evaluateWeek(weekId: number): Promise<void> {
     await this.dataSource.transaction(async manager => {
-      const weekRepository = manager.getRepository(RankingWeek);
-      const tierRepository = manager.getRepository(RankingTier);
-      const ruleRepository = manager.getRepository(RankingTierRule);
-      const groupRepository = manager.getRepository(RankingGroup);
-      const memberRepository = manager.getRepository(RankingGroupMember);
-      const weeklyXpRepository = manager.getRepository(RankingWeeklyXp);
-      const snapshotRepository = manager.getRepository(RankingWeeklySnapshot);
-      const tierChangeRepository = manager.getRepository(RankingTierChangeHistory);
-      const userRepository = manager.getRepository(User);
-      const rewardRepository = manager.getRepository(RankingRewardHistory);
-
-      const week = await weekRepository.findOne({
-        where: { id: weekId },
-        lock: { mode: 'pessimistic_write' },
-      });
+      const week = await this.lockAndMarkInProgress(manager, weekId);
       if (!week) {
         return;
       }
 
-      if (week.status === RankingWeekStatus.EVALUATED) {
-        return;
+      const result = await this.computeEvaluation(manager, week);
+      await this.persistEvaluation(manager, result);
+      await this.finalizeWeek(manager, week);
+    });
+  }
+
+  // 주차를 락으로 잠그고 진행 상태로 바꾼다. 없거나 이미 평가됐으면 null을 반환한다.
+  private async lockAndMarkInProgress(
+    manager: EntityManager,
+    weekId: number,
+  ): Promise<RankingWeek | null> {
+    const weekRepository = manager.getRepository(RankingWeek);
+
+    const week = await weekRepository.findOne({
+      where: { id: weekId },
+      lock: { mode: 'pessimistic_write' },
+    });
+    if (!week) {
+      return null;
+    }
+
+    if (week.status === RankingWeekStatus.EVALUATED) {
+      return null;
+    }
+
+    week.status = RankingWeekStatus.LOCKED;
+    await weekRepository.save(week);
+    return week;
+  }
+
+  // 티어와 그룹을 돌며 스냅샷, 티어 변동, 보상 내역을 계산한다. 읽기만 하고 저장은 하지 않는다.
+  private async computeEvaluation(
+    manager: EntityManager,
+    week: RankingWeek,
+  ): Promise<WeekEvaluationResult> {
+    const tierRepository = manager.getRepository(RankingTier);
+    const ruleRepository = manager.getRepository(RankingTierRule);
+    const groupRepository = manager.getRepository(RankingGroup);
+    const memberRepository = manager.getRepository(RankingGroupMember);
+    const weeklyXpRepository = manager.getRepository(RankingWeeklyXp);
+    const snapshotRepository = manager.getRepository(RankingWeeklySnapshot);
+    const tierChangeRepository = manager.getRepository(RankingTierChangeHistory);
+    const rewardRepository = manager.getRepository(RankingRewardHistory);
+
+    const tiers = await tierRepository.find({ order: { orderIndex: 'ASC' } });
+    const rules = await ruleRepository.find();
+    const ruleByTierId = new Map<number, RankingTierRule>(rules.map(rule => [rule.tierId, rule]));
+    const tierById = new Map<number, RankingTier>(tiers.map(tier => [tier.id, tier]));
+
+    const result: WeekEvaluationResult = {
+      snapshots: [],
+      tierChanges: [],
+      rewardHistories: [],
+      tierUpdates: [],
+      rewardAmountByUser: new Map<number, number>(),
+    };
+
+    for (const tier of tiers) {
+      const rule = ruleByTierId.get(tier.id);
+      if (!rule) {
+        this.logger.warn(`티어 룰셋이 없습니다: tierId=${tier.id}`);
+        continue;
       }
 
-      week.status = RankingWeekStatus.LOCKED;
-      await weekRepository.save(week);
+      const groups = await groupRepository.find({
+        where: { weekId: week.id, tierId: tier.id },
+        order: { groupIndex: 'ASC' },
+      });
 
-      const tiers = await tierRepository.find({ order: { orderIndex: 'ASC' } });
-      const rules = await ruleRepository.find();
-      const ruleByTierId = new Map<number, RankingTierRule>(rules.map(rule => [rule.tierId, rule]));
-      const tierById = new Map<number, RankingTier>(tiers.map(tier => [tier.id, tier]));
-
-      const tierChanges: RankingTierChangeHistory[] = [];
-      const rewardHistories: RankingRewardHistory[] = [];
-      const userUpdates: Array<{ userId: number; tierId: number }> = [];
-      const userRewardUpdates = new Map<number, number>();
-
-      for (const tier of tiers) {
-        const rule = ruleByTierId.get(tier.id);
-        if (!rule) {
-          this.logger.warn(`티어 룰셋이 없습니다: tierId=${tier.id}`);
+      for (const group of groups) {
+        const members = await memberRepository.find({
+          where: { groupId: group.id },
+          order: { joinedAt: 'ASC' },
+        });
+        if (members.length === 0) {
           continue;
         }
 
-        const groups = await groupRepository.find({
-          where: { weekId: week.id, tierId: tier.id },
-          order: { groupIndex: 'ASC' },
+        const memberIds = members.map(member => member.userId);
+        const weeklyXpList = await weeklyXpRepository.find({
+          where: { weekId: week.id, userId: In(memberIds) },
+        });
+        const weeklyXpMap = new Map(weeklyXpList.map(item => [item.userId, item]));
+
+        const scores = members.map(member => {
+          const weeklyXp = weeklyXpMap.get(member.userId);
+          const lastSolvedAt = weeklyXp?.lastSolvedAt ?? weeklyXp?.firstSolvedAt ?? member.joinedAt;
+
+          return {
+            userId: member.userId,
+            xp: weeklyXp?.xp ?? 0,
+            lastSolvedAt,
+          };
         });
 
-        for (const group of groups) {
-          const members = await memberRepository.find({
-            where: { groupId: group.id },
-            order: { joinedAt: 'ASC' },
-          });
+        const snapshotDrafts = buildRankingSnapshots({ members: scores, rule });
 
-          if (members.length === 0) {
-            continue;
-          }
-
-          const memberIds = members.map(member => member.userId);
-          const weeklyXpList = await weeklyXpRepository.find({
-            where: { weekId: week.id, userId: In(memberIds) },
-          });
-          const weeklyXpMap = new Map(weeklyXpList.map(item => [item.userId, item]));
-
-          const scores = members.map(member => {
-            const weeklyXp = weeklyXpMap.get(member.userId);
-            const lastSolvedAt =
-              weeklyXp?.lastSolvedAt ?? weeklyXp?.firstSolvedAt ?? member.joinedAt;
-
-            return {
-              userId: member.userId,
-              xp: weeklyXp?.xp ?? 0,
-              lastSolvedAt,
-            };
-          });
-
-          const snapshotDrafts = buildRankingSnapshots({ members: scores, rule });
-          const snapshots = snapshotDrafts.map(draft =>
+        for (const draft of snapshotDrafts) {
+          result.snapshots.push(
             snapshotRepository.create({
               weekId: week.id,
               tierId: tier.id,
@@ -171,78 +198,94 @@ export class RankingEvaluationService {
             }),
           );
 
-          if (snapshots.length > 0) {
-            await snapshotRepository.save(snapshots);
+          const tierChange = resolveTierChange({
+            tiers,
+            tierId: tier.id,
+            status: draft.status,
+          });
+
+          result.tierChanges.push(
+            tierChangeRepository.create({
+              weekId: week.id,
+              userId: draft.userId,
+              fromTierId: tierChange.fromTierId,
+              toTierId: tierChange.toTierId,
+              reason: tierChange.reason,
+            }),
+          );
+
+          if (tierChange.toTierId !== tierChange.fromTierId) {
+            result.tierUpdates.push({
+              userId: draft.userId,
+              tierId: tierChange.toTierId,
+            });
           }
 
-          for (const draft of snapshotDrafts) {
-            const tierChange = resolveTierChange({
-              tiers,
-              tierId: tier.id,
-              status: draft.status,
-            });
+          const isMasterMaintain =
+            tier.name === RankingTierName.MASTER &&
+            tierChange.reason === RankingTierChangeReason.MAINTAIN;
+          if (tierChange.reason === RankingTierChangeReason.PROMOTION || isMasterMaintain) {
+            const rewardTier = isMasterMaintain ? tier : tierById.get(tierChange.toTierId);
+            const rewardAmount = rewardTier ? this.getPromotionRewardAmount(rewardTier) : 0;
 
-            tierChanges.push(
-              tierChangeRepository.create({
+            result.rewardHistories.push(
+              rewardRepository.create({
                 weekId: week.id,
                 userId: draft.userId,
-                fromTierId: tierChange.fromTierId,
-                toTierId: tierChange.toTierId,
-                reason: tierChange.reason,
+                tierId: rewardTier?.id ?? tier.id,
+                rewardType: RankingRewardType.DIAMOND,
+                amount: rewardAmount,
               }),
             );
 
-            if (tierChange.toTierId !== tierChange.fromTierId) {
-              userUpdates.push({
-                userId: draft.userId,
-                tierId: tierChange.toTierId,
-              });
-            }
-
-            const isMasterMaintain =
-              tier.name === RankingTierName.MASTER &&
-              tierChange.reason === RankingTierChangeReason.MAINTAIN;
-            if (tierChange.reason === RankingTierChangeReason.PROMOTION || isMasterMaintain) {
-              const rewardTier = isMasterMaintain ? tier : tierById.get(tierChange.toTierId);
-              const rewardAmount = rewardTier ? this.getPromotionRewardAmount(rewardTier) : 0;
-              rewardHistories.push(
-                rewardRepository.create({
-                  weekId: week.id,
-                  userId: draft.userId,
-                  tierId: rewardTier?.id ?? tier.id,
-                  rewardType: RankingRewardType.DIAMOND,
-                  amount: rewardAmount,
-                }),
-              );
-
-              if (rewardAmount > 0) {
-                const currentAmount = userRewardUpdates.get(draft.userId) ?? 0;
-                userRewardUpdates.set(draft.userId, currentAmount + rewardAmount);
-              }
+            if (rewardAmount > 0) {
+              const currentAmount = result.rewardAmountByUser.get(draft.userId) ?? 0;
+              result.rewardAmountByUser.set(draft.userId, currentAmount + rewardAmount);
             }
           }
         }
       }
+    }
 
-      if (tierChanges.length > 0) {
-        await tierChangeRepository.save(tierChanges);
-      }
+    return result;
+  }
 
-      if (rewardHistories.length > 0) {
-        await rewardRepository.save(rewardHistories);
-      }
+  // 계산 결과를 저장하고 보상을 지급한다. 다이아는 increment로 적립해 동시 적립에도 값이 유지된다.
+  private async persistEvaluation(
+    manager: EntityManager,
+    result: WeekEvaluationResult,
+  ): Promise<void> {
+    const snapshotRepository = manager.getRepository(RankingWeeklySnapshot);
+    const tierChangeRepository = manager.getRepository(RankingTierChangeHistory);
+    const rewardRepository = manager.getRepository(RankingRewardHistory);
+    const userRepository = manager.getRepository(User);
 
-      for (const [userId, amount] of userRewardUpdates.entries()) {
-        await userRepository.increment({ id: userId }, 'diamondCount', amount);
-      }
+    if (result.snapshots.length > 0) {
+      await snapshotRepository.save(result.snapshots);
+    }
 
-      for (const update of userUpdates) {
-        await userRepository.update(update.userId, { currentTierId: update.tierId });
-      }
+    if (result.tierChanges.length > 0) {
+      await tierChangeRepository.save(result.tierChanges);
+    }
 
-      week.status = RankingWeekStatus.EVALUATED;
-      week.evaluatedAt = getKstNow();
-      await weekRepository.save(week);
-    });
+    if (result.rewardHistories.length > 0) {
+      await rewardRepository.save(result.rewardHistories);
+    }
+
+    for (const [userId, amount] of result.rewardAmountByUser.entries()) {
+      await userRepository.increment({ id: userId }, 'diamondCount', amount);
+    }
+
+    for (const update of result.tierUpdates) {
+      await userRepository.update(update.userId, { currentTierId: update.tierId });
+    }
+  }
+
+  // 주차를 평가 완료로 표시한다. 커밋 이후에는 멱등 가드에 걸려 다시 처리되지 않는다.
+  private async finalizeWeek(manager: EntityManager, week: RankingWeek): Promise<void> {
+    const weekRepository = manager.getRepository(RankingWeek);
+    week.status = RankingWeekStatus.EVALUATED;
+    week.evaluatedAt = getKstNow();
+    await weekRepository.save(week);
   }
 }

--- a/apps/backend/src/ranking/ranking-evaluation.service.ts
+++ b/apps/backend/src/ranking/ranking-evaluation.service.ts
@@ -146,8 +146,8 @@ export class RankingEvaluationService {
     for (const tier of tiers) {
       const rule = ruleByTierId.get(tier.id);
       if (!rule) {
-        this.logger.warn(`티어 룰셋이 없습니다: tierId=${tier.id}`);
-        continue;
+        // 한 티어라도 룰이 없으면 부분 정산이 되므로 전체를 롤백한다.
+        throw new Error(`티어 룰셋이 없습니다: tierId=${tier.id}`);
       }
 
       const groups = await groupRepository.find({

--- a/apps/backend/src/ranking/ranking-evaluation.utils.spec.ts
+++ b/apps/backend/src/ranking/ranking-evaluation.utils.spec.ts
@@ -70,6 +70,66 @@ describe('buildRankingSnapshots', () => {
     expect(snapshots[0]?.status).toBe(RankingSnapshotStatus.MAINTAINED);
     expect(snapshots[1]?.status).toBe(RankingSnapshotStatus.DEMOTED);
   });
+
+  it('상위 비율에 들어도 최소 XP에 못 미치면 승급하지 않는다', () => {
+    const rule = createRule({
+      promoteRatio: '1',
+      promoteMinXp: 100,
+      demoteRatio: '0',
+      demoteMinXp: 0,
+    });
+    const snapshots = buildRankingSnapshots({
+      members: [
+        { userId: 1, xp: 120, lastSolvedAt: new Date('2025-01-01') },
+        { userId: 2, xp: 80, lastSolvedAt: new Date('2025-01-02') },
+      ],
+      rule,
+    });
+
+    const statusByUser = new Map(snapshots.map(snapshot => [snapshot.userId, snapshot.status]));
+    expect(statusByUser.get(1)).toBe(RankingSnapshotStatus.PROMOTED);
+    expect(statusByUser.get(2)).not.toBe(RankingSnapshotStatus.PROMOTED);
+  });
+
+  it('승급 인원은 올림, 강등 인원은 내림으로 계산한다', () => {
+    const rule = createRule({
+      promoteRatio: '0.5',
+      demoteRatio: '0.5',
+      promoteMinXp: 0,
+      demoteMinXp: 0,
+    });
+    const snapshots = buildRankingSnapshots({
+      members: [
+        { userId: 1, xp: 30, lastSolvedAt: new Date('2025-01-01') },
+        { userId: 2, xp: 20, lastSolvedAt: new Date('2025-01-02') },
+        { userId: 3, xp: 10, lastSolvedAt: new Date('2025-01-03') },
+      ],
+      rule,
+    });
+
+    const promoted = snapshots.filter(s => s.status === RankingSnapshotStatus.PROMOTED);
+    const demoted = snapshots.filter(s => s.status === RankingSnapshotStatus.DEMOTED);
+    // 3명 * 0.5 -> 승급 ceil(1.5)=2, 강등 floor(1.5)=1
+    expect(promoted.length).toBe(2);
+    expect(demoted.length).toBe(1);
+  });
+
+  it('XP가 같으면 풀이 시각이 빠른 순, 같으면 사용자 ID 순으로 정렬한다', () => {
+    const rule = createRule({ promoteRatio: '0', demoteRatio: '0' });
+    const snapshots = buildRankingSnapshots({
+      members: [
+        { userId: 5, xp: 100, lastSolvedAt: new Date('2025-01-02') },
+        { userId: 7, xp: 100, lastSolvedAt: new Date('2025-01-01') },
+        { userId: 3, xp: 100, lastSolvedAt: new Date('2025-01-01') },
+      ],
+      rule,
+    });
+
+    const rankByUser = new Map(snapshots.map(snapshot => [snapshot.userId, snapshot.rank]));
+    expect(rankByUser.get(3)).toBe(1);
+    expect(rankByUser.get(7)).toBe(2);
+    expect(rankByUser.get(5)).toBe(3);
+  });
 });
 
 describe('resolveTierChange', () => {


### PR DESCRIPTION
## ⏱ 소요 시간

- 예상 소요 시간: 2시간
- 실제 작업 시간: 2시간

<br/>

## 📌 작업 요약

주간 랭킹 정산 로직을 잠금, 계산, 저장, 완료 처리 단계로 분리했습니다. 티어 정책이 누락된 경우 일부 사용자만 정산되는 문제를 막고 관련 테스트를 추가했습니다.

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. `evaluateWeek`가 전체 흐름만 보여주도록 메서드를 분리했습니다.
   - `lockAndMarkInProgress`: 주차 잠금 및 상태 확인
   - `computeEvaluation`: 스냅샷, 티어 변경, 보상 계산
   - `persistEvaluation`: 계산 결과 저장 및 보상 반영
   - `finalizeWeek`: 평가 완료 상태 확정
2. 특정 티어의 룰이 누락되면 해당 티어만 건너뛰지 않고 예외를 발생시켜 전체 정산을 롤백하도록 수정했습니다.
3. 최소 XP, 승강등 인원 계산, 동점 정렬, 완료된 주차의 재호출 등 정책과 서비스 흐름 테스트를 추가했습니다.
   - 테스트 15개 통과

<br/>

## 🚨 주요 고민 및 해결 과정

> 주요 고민이나 문제 해결 과정 공유

### 문제

기존 `evaluateWeek`에는 주차 잠금부터 정책 계산, 이력 저장, 보상 지급, 완료 처리까지 한 메서드에 들어 있었습니다. 트랜잭션 범위를 한눈에 파악하기 어렵고 정책이나 저장 순서를 수정할 때 확인해야 할 범위도 컸습니다.

또한 특정 티어의 룰이 없으면 경고만 남기고 다음 티어를 처리했습니다. 이 상태로 `EVALUATED`까지 반영되면 일부 티어가 정산되지 않았는데도 완료된 주차로 남아 재실행할 수 없었습니다.

### 해결 과정

정산 단위는 기존과 동일하게 한 주차로 유지했습니다. 트랜잭션을 나누지 않고 같은 `EntityManager` 안에서 잠금, 계산, 저장, 완료 처리의 역할만 메서드로 분리했습니다.

계산 결과는 `WeekEvaluationResult`에 모은 뒤 한 번에 저장하도록 정리했습니다. 티어 룰이 하나라도 누락되면 예외를 발생시켜 스냅샷, 보상, 완료 상태가 일부만 반영되지 않도록 했습니다.

테스트에서는 실제로 확인한 범위만 드러나도록 테스트 이름도 정리했습니다. 비관적 락 옵션 사용, 완료 상태의 순차 재호출 차단, 보상과 완료 처리가 같은 트랜잭션 콜백에서 실행되는지를 검증했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 주간 랭킹 평가가 더 안정적으로 처리되도록 개선되었습니다.
  * 이미 평가된 주차는 다시 처리되지 않으며, 잘못된 상태 전이를 방지합니다.
  * 티어 규칙이 없는 경우 중간 결과만 남지 않고 전체 처리가 안전하게 중단됩니다.
  * 승급/강등 판정과 동점 정렬 기준이 더 정확해졌습니다.

* **Tests**
  * 주간 평가와 승급/강등 규칙에 대한 검증이 추가되어 동작 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->