### PR TITLE
랭킹 2계층 캐시 및 분산 락 적용

### DIFF
--- a/apps/backend/src/common/cache/cache-load-coordinator.spec.ts
+++ b/apps/backend/src/common/cache/cache-load-coordinator.spec.ts
@@ -1,0 +1,122 @@
+import { CacheLoadCoordinator } from './cache-load-coordinator';
+import type { CacheStore } from './cache-store';
+import type { DistributedLock } from './distributed-lock';
+
+interface RankingValue {
+  members: number[];
+}
+
+describe('CacheLoadCoordinator', () => {
+  const originalPollInterval = process.env.RANKING_CACHE_LOCK_POLL_INTERVAL_MS;
+  const originalWaitTimeout = process.env.RANKING_CACHE_LOCK_WAIT_TIMEOUT_MS;
+  let cacheStore: jest.Mocked<CacheStore>;
+  let distributedLock: jest.Mocked<DistributedLock>;
+
+  beforeEach(() => {
+    process.env.RANKING_CACHE_LOCK_POLL_INTERVAL_MS = '1';
+    process.env.RANKING_CACHE_LOCK_WAIT_TIMEOUT_MS = '100';
+    cacheStore = {
+      get: jest.fn(),
+      set: jest.fn(),
+      del: jest.fn(),
+    };
+    distributedLock = {
+      tryAcquire: jest.fn(),
+      release: jest.fn(),
+    };
+  });
+
+  afterAll(() => {
+    if (originalPollInterval === undefined) {
+      delete process.env.RANKING_CACHE_LOCK_POLL_INTERVAL_MS;
+    } else {
+      process.env.RANKING_CACHE_LOCK_POLL_INTERVAL_MS = originalPollInterval;
+    }
+
+    if (originalWaitTimeout === undefined) {
+      delete process.env.RANKING_CACHE_LOCK_WAIT_TIMEOUT_MS;
+    } else {
+      process.env.RANKING_CACHE_LOCK_WAIT_TIMEOUT_MS = originalWaitTimeout;
+    }
+  });
+
+  it('유효한 캐시가 있으면 락을 획득하거나 값을 계산하지 않는다', async () => {
+    const cachedValue = { members: [1] };
+    cacheStore.get.mockResolvedValue(cachedValue);
+    const coordinator = new CacheLoadCoordinator(cacheStore, distributedLock);
+    const load = jest.fn();
+
+    const result = await coordinator.getOrLoad(createOptions(load));
+
+    expect(result).toEqual({ value: cachedValue, source: 'cache' });
+    expect(distributedLock.tryAcquire).not.toHaveBeenCalled();
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('동일 인스턴스의 동시 요청은 하나의 계산 Promise를 공유한다', async () => {
+    const lease = { key: 'lock:ranking:1', ownerToken: 'owner-1' };
+    cacheStore.get.mockResolvedValue(null);
+    distributedLock.tryAcquire.mockResolvedValue(lease);
+    const coordinator = new CacheLoadCoordinator(cacheStore, distributedLock);
+    let completeLoad: (value: RankingValue) => void = () => undefined;
+    const pendingLoad = new Promise<RankingValue>(resolve => {
+      completeLoad = resolve;
+    });
+    const load = jest.fn().mockReturnValue(pendingLoad);
+    const options = createOptions(load);
+
+    const leaderResultPromise = coordinator.getOrLoad(options);
+    const followerResultPromise = coordinator.getOrLoad(options);
+    completeLoad({ members: [1, 2] });
+
+    await expect(leaderResultPromise).resolves.toEqual({
+      value: { members: [1, 2] },
+      source: 'computed',
+    });
+    await expect(followerResultPromise).resolves.toEqual({
+      value: { members: [1, 2] },
+      source: 'local-follower',
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(distributedLock.release).toHaveBeenCalledWith(lease);
+  });
+
+  it('분산 락을 얻지 못한 요청은 락 소유자가 채운 캐시를 사용한다', async () => {
+    const cachedValue = { members: [3] };
+    cacheStore.get.mockResolvedValueOnce(null).mockResolvedValueOnce(cachedValue);
+    distributedLock.tryAcquire.mockResolvedValue(null);
+    const coordinator = new CacheLoadCoordinator(cacheStore, distributedLock);
+    const load = jest.fn();
+
+    const result = await coordinator.getOrLoad(createOptions(load));
+
+    expect(result).toEqual({ value: cachedValue, source: 'distributed-follower' });
+    expect(load).not.toHaveBeenCalled();
+    expect(distributedLock.release).not.toHaveBeenCalled();
+  });
+
+  it('원본 계산이 실패해도 획득한 분산 락을 해제한다', async () => {
+    const lease = { key: 'lock:ranking:1', ownerToken: 'owner-1' };
+    cacheStore.get.mockResolvedValue(null);
+    distributedLock.tryAcquire.mockResolvedValue(lease);
+    const coordinator = new CacheLoadCoordinator(cacheStore, distributedLock);
+    const load = jest.fn().mockRejectedValue(new Error('계산 실패'));
+
+    await expect(coordinator.getOrLoad(createOptions(load))).rejects.toThrow('계산 실패');
+    expect(distributedLock.release).toHaveBeenCalledWith(lease);
+  });
+
+  function createOptions(load: () => Promise<RankingValue>) {
+    return {
+      cacheKey: 'ranking:1',
+      ttlSeconds: 60,
+      isValid: (value: unknown): value is RankingValue => {
+        if (!value || typeof value !== 'object') {
+          return false;
+        }
+        return Array.isArray((value as { members?: unknown }).members);
+      },
+      load,
+    };
+  }
+});

--- a/apps/backend/src/common/cache/cache-load-coordinator.ts
+++ b/apps/backend/src/common/cache/cache-load-coordinator.ts
@@ -1,0 +1,207 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CACHE_STORE, type CacheStore } from './cache-store';
+import {
+  DISTRIBUTED_LOCK,
+  type DistributedLock,
+  type DistributedLockLease,
+} from './distributed-lock';
+
+const DEFAULT_LOCK_TTL_MILLISECONDS = 10_000;
+const DEFAULT_WAIT_TIMEOUT_MILLISECONDS = 10_000;
+const DEFAULT_POLL_INTERVAL_MILLISECONDS = 50;
+
+export type CacheLoadSource =
+  | 'cache'
+  | 'local-follower'
+  | 'distributed-follower'
+  | 'computed'
+  | 'fallback';
+
+export interface CacheLoadResult<T> {
+  value: T;
+  source: CacheLoadSource;
+}
+
+export interface CacheLoadOptions<T> {
+  cacheKey: string;
+  ttlSeconds: number;
+  isValid: (value: unknown) => value is T;
+  load: () => Promise<T>;
+}
+
+/**
+ * 캐시 미스 이후의 중복 재계산을 인스턴스 내부와 인스턴스 사이에서 차단한다.
+ *
+ * 같은 프로세스의 요청은 하나의 Promise를 공유하고, 프로세스 대표 요청만 분산 락을
+ * 획득해 값을 계산한다. 락 획득에 실패한 요청은 캐시가 채워질 때까지 제한된 시간 동안
+ * 기다린다.
+ */
+@Injectable()
+export class CacheLoadCoordinator {
+  private readonly inflightLoads = new Map<string, Promise<CacheLoadResult<unknown>>>();
+  private readonly lockTtlMilliseconds = this.readPositiveInteger(
+    process.env.RANKING_CACHE_LOCK_TTL_MS,
+    DEFAULT_LOCK_TTL_MILLISECONDS,
+  );
+  private readonly waitTimeoutMilliseconds = this.readPositiveInteger(
+    process.env.RANKING_CACHE_LOCK_WAIT_TIMEOUT_MS,
+    DEFAULT_WAIT_TIMEOUT_MILLISECONDS,
+  );
+  private readonly pollIntervalMilliseconds = this.readPositiveInteger(
+    process.env.RANKING_CACHE_LOCK_POLL_INTERVAL_MS,
+    DEFAULT_POLL_INTERVAL_MILLISECONDS,
+  );
+
+  constructor(
+    @Inject(CACHE_STORE)
+    private readonly cacheStore: CacheStore,
+    @Inject(DISTRIBUTED_LOCK)
+    private readonly distributedLock: DistributedLock,
+  ) {}
+
+  /**
+   * 캐시 값을 반환하거나, 중복 계산을 조정하면서 값을 한 번만 적재한다.
+   *
+   * @param options 캐시 키, TTL, 검증 함수와 원본 적재 함수
+   * @returns 값과 값을 얻은 경로
+   */
+  async getOrLoad<T>(options: CacheLoadOptions<T>): Promise<CacheLoadResult<T>> {
+    const cached = await this.readValidCachedValue(options);
+    if (cached !== null) {
+      return { value: cached, source: 'cache' };
+    }
+
+    const inflight = this.inflightLoads.get(options.cacheKey);
+    if (inflight) {
+      const result = (await inflight) as CacheLoadResult<T>;
+      return { value: result.value, source: 'local-follower' };
+    }
+
+    const loadPromise = this.loadAcrossInstances(options);
+    this.inflightLoads.set(options.cacheKey, loadPromise);
+
+    try {
+      return await loadPromise;
+    } finally {
+      if (this.inflightLoads.get(options.cacheKey) === loadPromise) {
+        this.inflightLoads.delete(options.cacheKey);
+      }
+    }
+  }
+
+  private async loadAcrossInstances<T>(options: CacheLoadOptions<T>): Promise<CacheLoadResult<T>> {
+    const lockKey = this.buildLockKey(options.cacheKey);
+    let lease: DistributedLockLease | null;
+
+    try {
+      lease = await this.distributedLock.tryAcquire(lockKey, this.lockTtlMilliseconds);
+    } catch {
+      return this.computeWithoutDistributedLock(options);
+    }
+
+    if (lease) {
+      return this.computeAsLockOwner(options, lease, 'computed');
+    }
+
+    return this.waitForLockOwner(options, lockKey);
+  }
+
+  private async waitForLockOwner<T>(
+    options: CacheLoadOptions<T>,
+    lockKey: string,
+  ): Promise<CacheLoadResult<T>> {
+    const deadline = Date.now() + this.waitTimeoutMilliseconds;
+
+    while (Date.now() < deadline) {
+      await this.delay(this.pollIntervalMilliseconds);
+
+      const cached = await this.readValidCachedValue(options);
+      if (cached !== null) {
+        return { value: cached, source: 'distributed-follower' };
+      }
+
+      let lease: DistributedLockLease | null;
+      try {
+        lease = await this.distributedLock.tryAcquire(lockKey, this.lockTtlMilliseconds);
+      } catch {
+        return this.computeWithoutDistributedLock(options);
+      }
+
+      if (lease) {
+        return this.computeAsLockOwner(options, lease, 'computed');
+      }
+    }
+
+    return this.computeWithoutDistributedLock(options);
+  }
+
+  private async computeAsLockOwner<T>(
+    options: CacheLoadOptions<T>,
+    lease: DistributedLockLease,
+    source: CacheLoadSource,
+  ): Promise<CacheLoadResult<T>> {
+    try {
+      const cached = await this.readValidCachedValue(options);
+      if (cached !== null) {
+        return { value: cached, source: 'distributed-follower' };
+      }
+
+      const value = await options.load();
+      await this.writeCacheWithoutBlockingResponse(options, value);
+      return { value, source };
+    } finally {
+      try {
+        await this.distributedLock.release(lease);
+      } catch {
+        // TTL이 락을 최종 해제하므로 Redis 장애 시 응답을 실패시키지 않는다.
+      }
+    }
+  }
+
+  private async computeWithoutDistributedLock<T>(
+    options: CacheLoadOptions<T>,
+  ): Promise<CacheLoadResult<T>> {
+    const value = await options.load();
+    await this.writeCacheWithoutBlockingResponse(options, value);
+    return { value, source: 'fallback' };
+  }
+
+  private async readValidCachedValue<T>(options: CacheLoadOptions<T>): Promise<T | null> {
+    try {
+      const cached = await this.cacheStore.get<unknown>(options.cacheKey);
+      return options.isValid(cached) ? cached : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeCacheWithoutBlockingResponse<T>(
+    options: CacheLoadOptions<T>,
+    value: T,
+  ): Promise<void> {
+    try {
+      await this.cacheStore.set(options.cacheKey, value, options.ttlSeconds);
+    } catch {
+      // 계산 결과를 반환할 수 있으므로 캐시 장애를 요청 오류로 전파하지 않는다.
+    }
+  }
+
+  private buildLockKey(cacheKey: string): string {
+    return `lock:${cacheKey}`;
+  }
+
+  private async delay(milliseconds: number): Promise<void> {
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, milliseconds);
+    });
+  }
+
+  private readPositiveInteger(rawValue: string | undefined, fallback: number): number {
+    const parsed = Number(rawValue);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      return fallback;
+    }
+    return parsed;
+  }
+}

--- a/apps/backend/src/common/cache/cache-store.ts
+++ b/apps/backend/src/common/cache/cache-store.ts
@@ -1,0 +1,33 @@
+/**
+ * 캐시 저장소 구현이 제공해야 하는 공통 계약이다.
+ *
+ * 랭킹 도메인이 Redis 같은 구체 기술을 직접 알지 않도록 읽기/쓰기/삭제 동작만 노출한다.
+ */
+export interface CacheStore {
+  /**
+   * 키에 저장된 값을 조회한다.
+   *
+   * @param key 캐시 키
+   * @returns 저장된 값 또는 캐시 미스일 때 null
+   */
+  get<T>(key: string): Promise<T | null>;
+
+  /**
+   * 값을 TTL과 함께 저장한다.
+   *
+   * @param key 캐시 키
+   * @param value 저장할 값
+   * @param ttlSeconds 만료 시간(초)
+   */
+  set<T>(key: string, value: T, ttlSeconds: number): Promise<void>;
+
+  /**
+   * 키에 저장된 값을 삭제한다.
+   *
+   * @param key 캐시 키
+   */
+  del(key: string): Promise<void>;
+}
+
+/** NestJS에서 캐시 저장소 구현을 교체하기 위한 주입 토큰이다. */
+export const CACHE_STORE = Symbol('CACHE_STORE');

--- a/apps/backend/src/common/cache/distributed-lock.ts
+++ b/apps/backend/src/common/cache/distributed-lock.ts
@@ -1,0 +1,31 @@
+/** 분산 락을 획득한 주체가 소유권을 증명하기 위해 사용하는 임대 정보다. */
+export interface DistributedLockLease {
+  key: string;
+  ownerToken: string;
+}
+
+/**
+ * 분산 락 구현이 제공해야 하는 공통 계약이다.
+ *
+ * 캐시 재계산 흐름이 Redis 명령 같은 구체 기술에 의존하지 않도록 락 동작만 노출한다.
+ */
+export interface DistributedLock {
+  /**
+   * 지정한 시간 동안 유효한 락 획득을 시도한다.
+   *
+   * @param key 락 키
+   * @param ttlMilliseconds 락 만료 시간(밀리초)
+   * @returns 획득한 락 임대 정보 또는 다른 소유자가 있을 때 null
+   */
+  tryAcquire(key: string, ttlMilliseconds: number): Promise<DistributedLockLease | null>;
+
+  /**
+   * 현재 소유자가 보유한 락만 해제한다.
+   *
+   * @param lease 해제할 락의 임대 정보
+   */
+  release(lease: DistributedLockLease): Promise<void>;
+}
+
+/** NestJS에서 분산 락 구현을 교체하기 위한 주입 토큰이다. */
+export const DISTRIBUTED_LOCK = Symbol('DISTRIBUTED_LOCK');

--- a/apps/backend/src/common/cache/layered-cache.store.spec.ts
+++ b/apps/backend/src/common/cache/layered-cache.store.spec.ts
@@ -1,0 +1,60 @@
+import { RedisService } from '../redis/redis.service';
+
+import { LayeredCacheStore } from './layered-cache.store';
+import { LocalCacheStore } from './local-cache.store';
+
+describe('LayeredCacheStore', () => {
+  const originalLocalTtl = process.env.RANKING_LOCAL_CACHE_TTL_SECONDS;
+  let localCacheStore: LocalCacheStore;
+  let redisService: Pick<RedisService, 'get' | 'set' | 'del'>;
+  let cacheStore: LayeredCacheStore;
+
+  beforeEach(() => {
+    process.env.RANKING_LOCAL_CACHE_TTL_SECONDS = '2';
+    localCacheStore = new LocalCacheStore();
+    redisService = {
+      get: jest.fn(),
+      set: jest.fn(),
+      del: jest.fn(),
+    };
+    cacheStore = new LayeredCacheStore(localCacheStore, redisService as RedisService);
+  });
+
+  afterAll(() => {
+    if (originalLocalTtl === undefined) {
+      delete process.env.RANKING_LOCAL_CACHE_TTL_SECONDS;
+    } else {
+      process.env.RANKING_LOCAL_CACHE_TTL_SECONDS = originalLocalTtl;
+    }
+  });
+
+  it('L1에 값이 있으면 Redis를 조회하지 않는다', async () => {
+    await cacheStore.set('ranking:1', { rank: 1 }, 60);
+
+    const result = await cacheStore.get('ranking:1');
+
+    expect(result).toEqual({ rank: 1 });
+    expect(redisService.get).not.toHaveBeenCalled();
+    expect(redisService.set).toHaveBeenCalledWith('ranking:1', { rank: 1 }, 60);
+  });
+
+  it('L2에서 조회한 값을 L1에 채워 다음 요청에서 재사용한다', async () => {
+    (redisService.get as jest.Mock).mockResolvedValue({ rank: 2 });
+
+    const firstResult = await cacheStore.get('ranking:2');
+    const secondResult = await cacheStore.get('ranking:2');
+
+    expect(firstResult).toEqual({ rank: 2 });
+    expect(secondResult).toEqual({ rank: 2 });
+    expect(redisService.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('삭제 요청을 두 캐시 계층에 모두 반영한다', async () => {
+    await cacheStore.set('ranking:3', { rank: 3 }, 60);
+
+    await cacheStore.del('ranking:3');
+
+    expect(await localCacheStore.get('ranking:3')).toBeNull();
+    expect(redisService.del).toHaveBeenCalledWith('ranking:3');
+  });
+});

--- a/apps/backend/src/common/cache/layered-cache.store.ts
+++ b/apps/backend/src/common/cache/layered-cache.store.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+
+import { RedisService } from '../redis/redis.service';
+
+import type { CacheStore } from './cache-store';
+import { LocalCacheStore } from './local-cache.store';
+
+const DEFAULT_LOCAL_TTL_SECONDS = 5;
+
+/**
+ * 로컬 캐시를 L1, Redis를 L2로 사용하는 2계층 캐시다.
+ *
+ * L1의 TTL을 짧게 제한해 인스턴스 간 데이터 차이가 유지되는 시간을 통제한다.
+ */
+@Injectable()
+export class LayeredCacheStore implements CacheStore {
+  private readonly localTtlSeconds = this.readPositiveInteger(
+    process.env.RANKING_LOCAL_CACHE_TTL_SECONDS,
+    DEFAULT_LOCAL_TTL_SECONDS,
+  );
+
+  constructor(
+    private readonly localCacheStore: LocalCacheStore,
+    private readonly redisService: RedisService,
+  ) {}
+
+  /**
+   * L1을 먼저 조회하고, 없으면 L2에서 가져와 L1을 채운다.
+   *
+   * @param key 캐시 키
+   * @returns 저장된 값 또는 두 계층 모두 캐시 미스일 때 null
+   */
+  async get<T>(key: string): Promise<T | null> {
+    const localValue = await this.localCacheStore.get<T>(key);
+    if (localValue !== null) {
+      return localValue;
+    }
+
+    const remoteValue = await this.redisService.get<T>(key);
+    if (remoteValue === null) {
+      return null;
+    }
+
+    await this.localCacheStore.set(key, remoteValue, this.localTtlSeconds);
+    return remoteValue;
+  }
+
+  /**
+   * L1에는 짧은 TTL로, L2에는 원래 TTL로 값을 기록한다.
+   *
+   * Redis 장애가 발생해도 현재 인스턴스는 계산 결과를 재사용할 수 있도록 L1을 먼저 갱신한다.
+   *
+   * @param key 캐시 키
+   * @param value 저장할 값
+   * @param ttlSeconds L2 만료 시간(초)
+   */
+  async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+    const effectiveLocalTtl = Math.min(ttlSeconds, this.localTtlSeconds);
+    await this.localCacheStore.set(key, value, effectiveLocalTtl);
+    await this.redisService.set(key, value, ttlSeconds);
+  }
+
+  /**
+   * 두 캐시 계층에서 키를 제거한다.
+   *
+   * @param key 캐시 키
+   */
+  async del(key: string): Promise<void> {
+    await this.localCacheStore.del(key);
+    await this.redisService.del(key);
+  }
+
+  private readPositiveInteger(rawValue: string | undefined, fallback: number): number {
+    const parsed = Number(rawValue);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      return fallback;
+    }
+    return parsed;
+  }
+}

--- a/apps/backend/src/common/cache/local-cache.store.spec.ts
+++ b/apps/backend/src/common/cache/local-cache.store.spec.ts
@@ -1,0 +1,44 @@
+import { LocalCacheStore } from './local-cache.store';
+
+describe('LocalCacheStore', () => {
+  const originalMaxEntries = process.env.RANKING_LOCAL_CACHE_MAX_ENTRIES;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalMaxEntries === undefined) {
+      delete process.env.RANKING_LOCAL_CACHE_MAX_ENTRIES;
+    } else {
+      process.env.RANKING_LOCAL_CACHE_MAX_ENTRIES = originalMaxEntries;
+    }
+  });
+
+  it('TTL이 지나면 저장된 값을 반환하지 않는다', async () => {
+    const cacheStore = new LocalCacheStore();
+    await cacheStore.set('ranking:1', { rank: 1 }, 2);
+
+    expect(await cacheStore.get('ranking:1')).toEqual({ rank: 1 });
+
+    jest.advanceTimersByTime(2_000);
+
+    expect(await cacheStore.get('ranking:1')).toBeNull();
+  });
+
+  it('최대 항목 수를 넘으면 가장 오랫동안 사용하지 않은 값을 제거한다', async () => {
+    process.env.RANKING_LOCAL_CACHE_MAX_ENTRIES = '2';
+    const cacheStore = new LocalCacheStore();
+
+    await cacheStore.set('first', 1, 60);
+    await cacheStore.set('second', 2, 60);
+    await cacheStore.get('first');
+    await cacheStore.set('third', 3, 60);
+
+    expect(await cacheStore.get('first')).toBe(1);
+    expect(await cacheStore.get('second')).toBeNull();
+    expect(await cacheStore.get('third')).toBe(3);
+  });
+});

--- a/apps/backend/src/common/cache/local-cache.store.ts
+++ b/apps/backend/src/common/cache/local-cache.store.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@nestjs/common';
+
+import type { CacheStore } from './cache-store';
+
+interface LocalCacheEntry {
+  value: unknown;
+  expiresAt: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 1_000;
+
+/**
+ * 한 애플리케이션 인스턴스 안에서 사용하는 크기 제한 LRU 캐시다.
+ *
+ * 오래된 값을 무기한 보관하지 않도록 항목별 TTL을 적용하고, 최대 개수를 넘으면
+ * 가장 오랫동안 사용하지 않은 항목부터 제거한다.
+ */
+@Injectable()
+export class LocalCacheStore implements CacheStore {
+  private readonly entries = new Map<string, LocalCacheEntry>();
+  private readonly maxEntries = this.readPositiveInteger(
+    process.env.RANKING_LOCAL_CACHE_MAX_ENTRIES,
+    DEFAULT_MAX_ENTRIES,
+  );
+
+  /**
+   * 만료되지 않은 값을 조회하고 최근 사용 항목으로 갱신한다.
+   *
+   * @param key 캐시 키
+   * @returns 저장된 값 또는 캐시 미스일 때 null
+   */
+  async get<T>(key: string): Promise<T | null> {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return null;
+    }
+
+    if (entry.expiresAt <= Date.now()) {
+      this.entries.delete(key);
+      return null;
+    }
+
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.value as T;
+  }
+
+  /**
+   * 값을 TTL과 함께 저장하고 최대 항목 수를 유지한다.
+   *
+   * @param key 캐시 키
+   * @param value 저장할 값
+   * @param ttlSeconds 만료 시간(초)
+   */
+  async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+    if (ttlSeconds <= 0) {
+      this.entries.delete(key);
+      return;
+    }
+
+    this.entries.delete(key);
+    this.entries.set(key, {
+      value,
+      expiresAt: Date.now() + ttlSeconds * 1_000,
+    });
+
+    this.evictLeastRecentlyUsedEntry();
+  }
+
+  /**
+   * 로컬 캐시에서 키를 제거한다.
+   *
+   * @param key 캐시 키
+   */
+  async del(key: string): Promise<void> {
+    this.entries.delete(key);
+  }
+
+  private evictLeastRecentlyUsedEntry(): void {
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value as string | undefined;
+      if (oldestKey === undefined) {
+        return;
+      }
+      this.entries.delete(oldestKey);
+    }
+  }
+
+  private readPositiveInteger(rawValue: string | undefined, fallback: number): number {
+    const parsed = Number(rawValue);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      return fallback;
+    }
+    return parsed;
+  }
+}

--- a/apps/backend/src/common/cache/redis-distributed-lock.service.spec.ts
+++ b/apps/backend/src/common/cache/redis-distributed-lock.service.spec.ts
@@ -1,0 +1,43 @@
+import { RedisService } from '../redis/redis.service';
+
+import { RedisDistributedLockService } from './redis-distributed-lock.service';
+
+describe('RedisDistributedLockService', () => {
+  let redisService: Pick<RedisService, 'setIfAbsent' | 'compareAndDelete'>;
+  let distributedLock: RedisDistributedLockService;
+
+  beforeEach(() => {
+    redisService = {
+      setIfAbsent: jest.fn(),
+      compareAndDelete: jest.fn(),
+    };
+    distributedLock = new RedisDistributedLockService(redisService as RedisService);
+  });
+
+  it('조건부 저장에 성공하면 소유권 토큰이 포함된 임대 정보를 반환한다', async () => {
+    (redisService.setIfAbsent as jest.Mock).mockResolvedValue(true);
+
+    const lease = await distributedLock.tryAcquire('lock:ranking:1', 10_000);
+
+    expect(lease).not.toBeNull();
+    expect(redisService.setIfAbsent).toHaveBeenCalledWith(
+      'lock:ranking:1',
+      lease?.ownerToken,
+      10_000,
+    );
+  });
+
+  it('이미 다른 소유자가 있으면 null을 반환한다', async () => {
+    (redisService.setIfAbsent as jest.Mock).mockResolvedValue(false);
+
+    await expect(distributedLock.tryAcquire('lock:ranking:1', 10_000)).resolves.toBeNull();
+  });
+
+  it('획득 시 발급한 토큰으로만 락 해제를 요청한다', async () => {
+    const lease = { key: 'lock:ranking:1', ownerToken: 'owner-1' };
+
+    await distributedLock.release(lease);
+
+    expect(redisService.compareAndDelete).toHaveBeenCalledWith('lock:ranking:1', 'owner-1');
+  });
+});

--- a/apps/backend/src/common/cache/redis-distributed-lock.service.ts
+++ b/apps/backend/src/common/cache/redis-distributed-lock.service.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from 'node:crypto';
+
+import { Injectable } from '@nestjs/common';
+
+import { RedisService } from '../redis/redis.service';
+
+import type { DistributedLock, DistributedLockLease } from './distributed-lock';
+
+/**
+ * Redis의 원자적 조건부 저장과 소유권 확인 삭제를 사용하는 분산 락이다.
+ */
+@Injectable()
+export class RedisDistributedLockService implements DistributedLock {
+  constructor(private readonly redisService: RedisService) {}
+
+  /**
+   * 다른 인스턴스가 보유하지 않은 락만 획득한다.
+   *
+   * @param key 락 키
+   * @param ttlMilliseconds 락 만료 시간(밀리초)
+   * @returns 획득한 락 임대 정보 또는 null
+   */
+  async tryAcquire(key: string, ttlMilliseconds: number): Promise<DistributedLockLease | null> {
+    const ownerToken = randomUUID();
+    const acquired = await this.redisService.setIfAbsent(key, ownerToken, ttlMilliseconds);
+    if (!acquired) {
+      return null;
+    }
+
+    return { key, ownerToken };
+  }
+
+  /**
+   * 락을 획득할 때 발급한 토큰이 일치하는 경우에만 해제한다.
+   *
+   * @param lease 해제할 락의 임대 정보
+   */
+  async release(lease: DistributedLockLease): Promise<void> {
+    await this.redisService.compareAndDelete(lease.key, lease.ownerToken);
+  }
+}

--- a/apps/backend/src/common/redis/redis.service.ts
+++ b/apps/backend/src/common/redis/redis.service.ts
@@ -1,8 +1,10 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import Redis from 'ioredis';
 
+import type { CacheStore } from '../cache/cache-store';
+
 @Injectable()
-export class RedisService implements OnModuleInit, OnModuleDestroy {
+export class RedisService implements CacheStore, OnModuleInit, OnModuleDestroy {
   private client!: Redis;
 
   onModuleInit() {
@@ -17,14 +19,14 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
   }
 
   // 데이터 저장 (TTL 포함)
-  async set(key: string, value: unknown, ttlSeconds: number) {
+  async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
     await this.client.set(key, JSON.stringify(value), 'EX', ttlSeconds);
   }
 
   // 데이터 가져오기
-  async get(key: string) {
+  async get<T>(key: string): Promise<T | null> {
     const data = await this.client.get(key);
-    return data ? JSON.parse(data) : null;
+    return data ? (JSON.parse(data) as T) : null;
   }
 
   // 데이터 삭제

--- a/apps/backend/src/common/redis/redis.service.ts
+++ b/apps/backend/src/common/redis/redis.service.ts
@@ -33,4 +33,40 @@ export class RedisService implements CacheStore, OnModuleInit, OnModuleDestroy {
   async del(key: string): Promise<void> {
     await this.client.del(key);
   }
+
+  /**
+   * 키가 없을 때만 값을 밀리초 TTL과 함께 저장한다.
+   *
+   * 분산 락 획득을 하나의 Redis 명령으로 처리해 인스턴스 간 경쟁을 원자적으로 조정한다.
+   *
+   * @param key 저장할 키
+   * @param value 락 소유권을 식별할 값
+   * @param ttlMilliseconds 만료 시간(밀리초)
+   * @returns 저장에 성공했으면 true
+   */
+  async setIfAbsent(key: string, value: string, ttlMilliseconds: number): Promise<boolean> {
+    const result = await this.client.set(key, value, 'PX', ttlMilliseconds, 'NX');
+    return result === 'OK';
+  }
+
+  /**
+   * 현재 값이 예상한 소유권 토큰과 일치할 때만 키를 삭제한다.
+   *
+   * 만료된 락을 새로 획득한 다른 인스턴스의 락을 지우지 않도록 비교와 삭제를
+   * 하나의 Lua 스크립트로 실행한다.
+   *
+   * @param key 삭제할 키
+   * @param expectedValue 락을 획득할 때 발급한 소유권 토큰
+   * @returns 키를 삭제했으면 true
+   */
+  async compareAndDelete(key: string, expectedValue: string): Promise<boolean> {
+    const script = `
+      if redis.call("GET", KEYS[1]) == ARGV[1] then
+        return redis.call("DEL", KEYS[1])
+      end
+      return 0
+    `;
+    const result = await this.client.eval(script, 1, key, expectedValue);
+    return Number(result) === 1;
+  }
 }

--- a/apps/backend/src/ranking/ranking-query.service.spec.ts
+++ b/apps/backend/src/ranking/ranking-query.service.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 
+import { CacheLoadCoordinator } from '../common/cache/cache-load-coordinator';
 import type { CacheStore } from '../common/cache/cache-store';
 import { rankingCacheCounter } from '../metrics/experiment-metrics';
 import { User } from '../users/entities/user.entity';
@@ -30,6 +31,7 @@ describe('RankingQueryService', () => {
   let tierRuleRepository: Partial<Repository<RankingTierRule>>;
   let userRepository: Partial<Repository<User>>;
   let cacheStore: Partial<CacheStore>;
+  let cacheLoadCoordinator: Partial<CacheLoadCoordinator>;
   const incrementCacheCounter = rankingCacheCounter.inc as jest.Mock;
 
   beforeEach(() => {
@@ -42,6 +44,7 @@ describe('RankingQueryService', () => {
     tierRuleRepository = { findOne: jest.fn() };
     userRepository = { findOne: jest.fn() };
     cacheStore = { get: jest.fn(), set: jest.fn() };
+    cacheLoadCoordinator = { getOrLoad: jest.fn() };
 
     service = new RankingQueryService(
       weekRepository as Repository<RankingWeek>,
@@ -52,6 +55,7 @@ describe('RankingQueryService', () => {
       tierRuleRepository as Repository<RankingTierRule>,
       userRepository as Repository<User>,
       cacheStore as CacheStore,
+      cacheLoadCoordinator as CacheLoadCoordinator,
     );
   });
 

--- a/apps/backend/src/ranking/ranking-query.service.spec.ts
+++ b/apps/backend/src/ranking/ranking-query.service.spec.ts
@@ -22,6 +22,7 @@ jest.mock('../metrics/experiment-metrics', () => ({
 }));
 
 describe('RankingQueryService', () => {
+  const originalCacheGranularity = process.env.RANKING_CACHE_GRANULARITY;
   let service: RankingQueryService;
   let weekRepository: Partial<Repository<RankingWeek>>;
   let groupRepository: Partial<Repository<RankingGroup>>;
@@ -35,6 +36,7 @@ describe('RankingQueryService', () => {
   const incrementCacheCounter = rankingCacheCounter.inc as jest.Mock;
 
   beforeEach(() => {
+    process.env.RANKING_CACHE_GRANULARITY = 'user';
     incrementCacheCounter.mockClear();
     weekRepository = { findOne: jest.fn() };
     groupRepository = { findOne: jest.fn() };
@@ -46,7 +48,19 @@ describe('RankingQueryService', () => {
     cacheStore = { get: jest.fn(), set: jest.fn() };
     cacheLoadCoordinator = { getOrLoad: jest.fn() };
 
-    service = new RankingQueryService(
+    service = createService();
+  });
+
+  afterAll(() => {
+    if (originalCacheGranularity === undefined) {
+      delete process.env.RANKING_CACHE_GRANULARITY;
+    } else {
+      process.env.RANKING_CACHE_GRANULARITY = originalCacheGranularity;
+    }
+  });
+
+  function createService(): RankingQueryService {
+    return new RankingQueryService(
       weekRepository as Repository<RankingWeek>,
       groupRepository as Repository<RankingGroup>,
       memberRepository as Repository<RankingGroupMember>,
@@ -57,7 +71,7 @@ describe('RankingQueryService', () => {
       cacheStore as CacheStore,
       cacheLoadCoordinator as CacheLoadCoordinator,
     );
-  });
+  }
 
   it('내 티어를 반환한다', async () => {
     const tier = { id: 10, name: RankingTierName.SILVER, orderIndex: 2 } as RankingTier;
@@ -132,6 +146,53 @@ describe('RankingQueryService', () => {
     expect(result).toBe(cachedResult);
     expect(incrementCacheCounter).toHaveBeenCalledWith({ cache: 'weekly', result: 'hit' });
     expect(weekRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('그룹 캐시 경로에서는 계층 캐시와 분산 락 조정기를 사용한다', async () => {
+    process.env.RANKING_CACHE_GRANULARITY = 'group';
+    service = createService();
+    const memberRef = {
+      kind: 'group',
+      weekId: 1,
+      groupId: 7,
+      tierId: 3,
+      groupIndex: 1,
+      tier: { id: 3, name: RankingTierName.GOLD, orderIndex: 3 },
+    };
+    const cachedGroupRanking = {
+      weekKey: '2025-01',
+      tier: memberRef.tier,
+      groupIndex: 1,
+      totalMembers: 1,
+      members: [
+        {
+          userId: 1,
+          displayName: 'A',
+          profileImageUrl: null,
+          xp: 10,
+          rank: 1,
+          isMe: false,
+          rankZone: 'PROMOTION',
+        },
+      ],
+    };
+    (cacheStore.get as jest.Mock).mockResolvedValue(memberRef);
+    (cacheLoadCoordinator.getOrLoad as jest.Mock).mockResolvedValue({
+      value: cachedGroupRanking,
+      source: 'cache',
+    });
+
+    const result = await service.getWeeklyRanking(1, '2025-01');
+
+    expect(cacheLoadCoordinator.getOrLoad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cacheKey: 'ranking:weekly:2025-01:group:7',
+        ttlSeconds: 60,
+      }),
+    );
+    expect(result.myRank).toBe(1);
+    expect(result.members[0]?.isMe).toBe(true);
+    expect(incrementCacheCounter).toHaveBeenCalledWith({ cache: 'weekly', result: 'hit' });
   });
 
   it('주간 전체 랭킹을 XP 기준으로 정렬해 반환한다', async () => {

--- a/apps/backend/src/ranking/ranking-query.service.spec.ts
+++ b/apps/backend/src/ranking/ranking-query.service.spec.ts
@@ -1,7 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 
-import { RedisService } from '../common/redis/redis.service';
+import type { CacheStore } from '../common/cache/cache-store';
 import { rankingCacheCounter } from '../metrics/experiment-metrics';
 import { User } from '../users/entities/user.entity';
 
@@ -29,7 +29,7 @@ describe('RankingQueryService', () => {
   let tierRepository: Partial<Repository<RankingTier>>;
   let tierRuleRepository: Partial<Repository<RankingTierRule>>;
   let userRepository: Partial<Repository<User>>;
-  let redisService: Partial<RedisService>;
+  let cacheStore: Partial<CacheStore>;
   const incrementCacheCounter = rankingCacheCounter.inc as jest.Mock;
 
   beforeEach(() => {
@@ -41,7 +41,7 @@ describe('RankingQueryService', () => {
     tierRepository = { findOne: jest.fn() };
     tierRuleRepository = { findOne: jest.fn() };
     userRepository = { findOne: jest.fn() };
-    redisService = { get: jest.fn(), set: jest.fn() };
+    cacheStore = { get: jest.fn(), set: jest.fn() };
 
     service = new RankingQueryService(
       weekRepository as Repository<RankingWeek>,
@@ -51,7 +51,7 @@ describe('RankingQueryService', () => {
       tierRepository as Repository<RankingTier>,
       tierRuleRepository as Repository<RankingTierRule>,
       userRepository as Repository<User>,
-      redisService as RedisService,
+      cacheStore as CacheStore,
     );
   });
 
@@ -121,7 +121,7 @@ describe('RankingQueryService', () => {
       myWeeklyXp: 0,
       members: [],
     };
-    (redisService.get as jest.Mock).mockResolvedValue(cachedResult);
+    (cacheStore.get as jest.Mock).mockResolvedValue(cachedResult);
 
     const result = await service.getWeeklyRanking(1, '2025-01');
 
@@ -209,7 +209,7 @@ describe('RankingQueryService', () => {
       myWeeklyXp: 0,
       members: [],
     };
-    (redisService.get as jest.Mock).mockResolvedValue(cachedResult);
+    (cacheStore.get as jest.Mock).mockResolvedValue(cachedResult);
 
     const result = await service.getOverallWeeklyRanking(1, '2025-01');
 

--- a/apps/backend/src/ranking/ranking-query.service.ts
+++ b/apps/backend/src/ranking/ranking-query.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
 import { CACHE_TTL_SECONDS, CacheKeys } from '../common/cache/cache-keys';
+import { CacheLoadCoordinator, type CacheLoadSource } from '../common/cache/cache-load-coordinator';
 import { CACHE_STORE, type CacheStore } from '../common/cache/cache-store';
 import { getKstNow, getKstWeekInfo } from '../common/utils/kst-date';
 import { rankingCacheCounter } from '../metrics/experiment-metrics';
@@ -68,6 +69,7 @@ export class RankingQueryService {
     private readonly userRepository: Repository<User>,
     @Inject(CACHE_STORE)
     private readonly cacheStore: CacheStore,
+    private readonly cacheLoadCoordinator: CacheLoadCoordinator,
   ) {}
 
   /**
@@ -76,15 +78,6 @@ export class RankingQueryService {
    */
   private readonly cacheGranularity: 'user' | 'group' =
     process.env.RANKING_CACHE_GRANULARITY === 'group' ? 'group' : 'user';
-
-  /**
-   * 같은 그룹의 동시 재계산을 현재 프로세스 안에서 합친다.
-   * 그룹 캐시를 사용할 때만 적용한다.
-   */
-  private readonly singleFlight: boolean = process.env.RANKING_SINGLE_FLIGHT === '1';
-
-  /** 그룹별로 진행 중인 랭킹 계산을 보관한다. */
-  private readonly inflightGroupRankings = new Map<string, Promise<CachedWeeklyGroupRanking>>();
 
   /**
    * 현재 사용자 기준으로 티어 정보를 반환한다.
@@ -215,88 +208,49 @@ export class RankingQueryService {
 
     const cacheKey = CacheKeys.rankingWeeklyGroup(targetWeekKey, ref.groupId);
 
-    if (this.singleFlight) {
-      const group = await this.getOrComputeGroupRanking(
-        cacheKey,
-        targetWeekKey,
-        ref.weekId,
-        ref.groupId,
-        ref.tierId,
-        ref.groupIndex,
-        ref.tier,
-      );
-      return this.deriveUserWeeklyView(group, userId);
-    }
-
-    const cachedGroup = await this.getCachedGroupRanking(cacheKey);
-    if (cachedGroup) {
-      rankingCacheCounter.inc({ cache: 'weekly', result: 'hit' });
-      return this.deriveUserWeeklyView(cachedGroup, userId);
-    }
-    rankingCacheCounter.inc({ cache: 'weekly', result: 'miss' });
-
-    const group = await this.computeGroupRanking(
-      targetWeekKey,
-      ref.weekId,
-      ref.groupId,
-      ref.tierId,
-      ref.groupIndex,
-      ref.tier,
-    );
-    await this.setCachedGroupRanking(cacheKey, group);
-    return this.deriveUserWeeklyView(group, userId);
+    const result = await this.cacheLoadCoordinator.getOrLoad<CachedWeeklyGroupRanking>({
+      cacheKey,
+      ttlSeconds: CACHE_TTL_SECONDS.ranking,
+      isValid: (value): value is CachedWeeklyGroupRanking => this.isCachedGroupRanking(value),
+      load: () =>
+        this.computeGroupRanking(
+          targetWeekKey,
+          ref.weekId,
+          ref.groupId,
+          ref.tierId,
+          ref.groupIndex,
+          ref.tier,
+        ),
+    });
+    this.recordCoordinatedCacheMetrics(result.source);
+    return this.deriveUserWeeklyView(result.value, userId);
   }
 
-  /**
-   * 캐시가 없을 때 같은 그룹에서 진행 중인 계산을 재사용한다.
-   *
-   * @param cacheKey 그룹 랭킹 캐시 키
-   * @param weekKey 조회할 주차 키
-   * @param weekId 주차 ID
-   * @param groupId 그룹 ID
-   * @param tierId 티어 ID
-   * @param groupIndex 그룹 번호
-   * @param tier 티어 정보
-   * @returns 그룹 공통 주간 랭킹
-   */
-  private async getOrComputeGroupRanking(
-    cacheKey: string,
-    weekKey: string,
-    weekId: number,
-    groupId: number,
-    tierId: number | null,
-    groupIndex: number,
-    tier: RankingTierSummary | null,
-  ): Promise<CachedWeeklyGroupRanking> {
-    const cached = await this.getCachedGroupRanking(cacheKey);
-    if (cached) {
+  private recordCoordinatedCacheMetrics(source: CacheLoadSource): void {
+    if (source === 'cache') {
       rankingCacheCounter.inc({ cache: 'weekly', result: 'hit' });
-      return cached;
-    }
-
-    // 조회와 등록 사이에 비동기 작업이 없어 같은 키의 계산이 중복 등록되지 않는다.
-    const inflight = this.inflightGroupRankings.get(cacheKey);
-    if (inflight) {
-      rankingCacheCounter.inc({ cache: 'weekly_sf', result: 'follower' });
-      return inflight;
+      return;
     }
 
     rankingCacheCounter.inc({ cache: 'weekly', result: 'miss' });
+
+    if (source === 'local-follower') {
+      rankingCacheCounter.inc({ cache: 'weekly_sf', result: 'follower' });
+      return;
+    }
+
+    if (source === 'distributed-follower') {
+      rankingCacheCounter.inc({ cache: 'weekly_lock', result: 'follower' });
+      return;
+    }
+
+    if (source === 'fallback') {
+      rankingCacheCounter.inc({ cache: 'weekly_lock', result: 'fallback' });
+      return;
+    }
+
     rankingCacheCounter.inc({ cache: 'weekly_sf', result: 'leader' });
-
-    const promise = this.computeGroupRanking(weekKey, weekId, groupId, tierId, groupIndex, tier)
-      .then(async group => {
-        await this.setCachedGroupRanking(cacheKey, group);
-        this.inflightGroupRankings.delete(cacheKey);
-        return group;
-      })
-      .catch((err: unknown) => {
-        this.inflightGroupRankings.delete(cacheKey);
-        throw err;
-      });
-
-    this.inflightGroupRankings.set(cacheKey, promise);
-    return promise;
+    rankingCacheCounter.inc({ cache: 'weekly_lock', result: 'leader' });
   }
 
   /**
@@ -468,26 +422,6 @@ export class RankingQueryService {
 
   private toTierSummary(tier: RankingTier | null | undefined): RankingTierSummary | null {
     return tier ? { id: tier.id, name: tier.name, orderIndex: tier.orderIndex } : null;
-  }
-
-  private async getCachedGroupRanking(cacheKey: string): Promise<CachedWeeklyGroupRanking | null> {
-    try {
-      const cached = await this.cacheStore.get(cacheKey);
-      return this.isCachedGroupRanking(cached) ? cached : null;
-    } catch {
-      return null;
-    }
-  }
-
-  private async setCachedGroupRanking(
-    cacheKey: string,
-    group: CachedWeeklyGroupRanking,
-  ): Promise<void> {
-    try {
-      await this.cacheStore.set(cacheKey, group, CACHE_TTL_SECONDS.ranking);
-    } catch {
-      // 캐시는 다시 만들 수 있으므로 저장 실패를 요청 오류로 처리하지 않는다.
-    }
   }
 
   private isCachedGroupRanking(value: unknown): value is CachedWeeklyGroupRanking {

--- a/apps/backend/src/ranking/ranking-query.service.ts
+++ b/apps/backend/src/ranking/ranking-query.service.ts
@@ -1,9 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
 import { CACHE_TTL_SECONDS, CacheKeys } from '../common/cache/cache-keys';
-import { RedisService } from '../common/redis/redis.service';
+import { CACHE_STORE, type CacheStore } from '../common/cache/cache-store';
 import { getKstNow, getKstWeekInfo } from '../common/utils/kst-date';
 import { rankingCacheCounter } from '../metrics/experiment-metrics';
 import { User } from '../users/entities/user.entity';
@@ -66,7 +66,8 @@ export class RankingQueryService {
     private readonly tierRuleRepository: Repository<RankingTierRule>,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
-    private readonly redisService: RedisService,
+    @Inject(CACHE_STORE)
+    private readonly cacheStore: CacheStore,
   ) {}
 
   /**
@@ -311,7 +312,7 @@ export class RankingQueryService {
   ): Promise<WeeklyMemberRef> {
     const refKey = CacheKeys.rankingWeeklyMemberRef(targetWeekKey, userId);
     try {
-      const cached = await this.redisService.get(refKey);
+      const cached = await this.cacheStore.get(refKey);
       if (this.isWeeklyMemberRef(cached)) {
         rankingCacheCounter.inc({ cache: 'weekly_member', result: 'hit' });
         return cached;
@@ -345,7 +346,7 @@ export class RankingQueryService {
     }
 
     try {
-      await this.redisService.set(refKey, ref, CACHE_TTL_SECONDS.ranking);
+      await this.cacheStore.set(refKey, ref, CACHE_TTL_SECONDS.ranking);
     } catch {
       // 소속 정보는 다시 조회할 수 있으므로 저장 실패를 요청 오류로 처리하지 않는다.
     }
@@ -471,7 +472,7 @@ export class RankingQueryService {
 
   private async getCachedGroupRanking(cacheKey: string): Promise<CachedWeeklyGroupRanking | null> {
     try {
-      const cached = await this.redisService.get(cacheKey);
+      const cached = await this.cacheStore.get(cacheKey);
       return this.isCachedGroupRanking(cached) ? cached : null;
     } catch {
       return null;
@@ -483,7 +484,7 @@ export class RankingQueryService {
     group: CachedWeeklyGroupRanking,
   ): Promise<void> {
     try {
-      await this.redisService.set(cacheKey, group, CACHE_TTL_SECONDS.ranking);
+      await this.cacheStore.set(cacheKey, group, CACHE_TTL_SECONDS.ranking);
     } catch {
       // 캐시는 다시 만들 수 있으므로 저장 실패를 요청 오류로 처리하지 않는다.
     }
@@ -888,7 +889,7 @@ export class RankingQueryService {
     const cacheKey = CacheKeys.rankingWeekly(weekKey, userId);
 
     try {
-      const cached = await this.redisService.get(cacheKey);
+      const cached = await this.cacheStore.get(cacheKey);
       if (!this.isWeeklyRankingResult(cached)) {
         return null;
       }
@@ -906,7 +907,7 @@ export class RankingQueryService {
     const cacheKey = CacheKeys.rankingWeekly(weekKey, userId);
 
     try {
-      await this.redisService.set(cacheKey, result, CACHE_TTL_SECONDS.ranking);
+      await this.cacheStore.set(cacheKey, result, CACHE_TTL_SECONDS.ranking);
     } catch {
       return;
     }
@@ -919,7 +920,7 @@ export class RankingQueryService {
     const cacheKey = CacheKeys.rankingOverall(weekKey, userId);
 
     try {
-      const cached = await this.redisService.get(cacheKey);
+      const cached = await this.cacheStore.get(cacheKey);
       if (!this.isOverallRankingResult(cached)) {
         return null;
       }
@@ -937,7 +938,7 @@ export class RankingQueryService {
     const cacheKey = CacheKeys.rankingOverall(weekKey, userId);
 
     try {
-      await this.redisService.set(cacheKey, result, CACHE_TTL_SECONDS.ranking);
+      await this.cacheStore.set(cacheKey, result, CACHE_TTL_SECONDS.ranking);
     } catch {
       return;
     }

--- a/apps/backend/src/ranking/ranking.module.ts
+++ b/apps/backend/src/ranking/ranking.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { CacheLoadCoordinator } from '../common/cache/cache-load-coordinator';
 import { CACHE_STORE } from '../common/cache/cache-store';
+import { DISTRIBUTED_LOCK } from '../common/cache/distributed-lock';
 import { LayeredCacheStore } from '../common/cache/layered-cache.store';
 import { LocalCacheStore } from '../common/cache/local-cache.store';
+import { RedisDistributedLockService } from '../common/cache/redis-distributed-lock.service';
 import { RedisService } from '../common/redis/redis.service';
 import { User } from '../users/entities/user.entity';
 
@@ -45,9 +48,15 @@ import { RankingQueryService } from './ranking-query.service';
     RedisService,
     LocalCacheStore,
     LayeredCacheStore,
+    CacheLoadCoordinator,
+    RedisDistributedLockService,
     {
       provide: CACHE_STORE,
       useExisting: LayeredCacheStore,
+    },
+    {
+      provide: DISTRIBUTED_LOCK,
+      useExisting: RedisDistributedLockService,
     },
   ],
   exports: [RankingService],

--- a/apps/backend/src/ranking/ranking.module.ts
+++ b/apps/backend/src/ranking/ranking.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { CACHE_STORE } from '../common/cache/cache-store';
 import { RedisService } from '../common/redis/redis.service';
 import { User } from '../users/entities/user.entity';
 
@@ -35,7 +36,16 @@ import { RankingQueryService } from './ranking-query.service';
     ]),
   ],
   controllers: [RankingController, AdminRankingController],
-  providers: [RankingService, RankingEvaluationService, RankingQueryService, RedisService],
+  providers: [
+    RankingService,
+    RankingEvaluationService,
+    RankingQueryService,
+    RedisService,
+    {
+      provide: CACHE_STORE,
+      useExisting: RedisService,
+    },
+  ],
   exports: [RankingService],
 })
 export class RankingModule {}

--- a/apps/backend/src/ranking/ranking.module.ts
+++ b/apps/backend/src/ranking/ranking.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CACHE_STORE } from '../common/cache/cache-store';
+import { LayeredCacheStore } from '../common/cache/layered-cache.store';
+import { LocalCacheStore } from '../common/cache/local-cache.store';
 import { RedisService } from '../common/redis/redis.service';
 import { User } from '../users/entities/user.entity';
 
@@ -41,9 +43,11 @@ import { RankingQueryService } from './ranking-query.service';
     RankingEvaluationService,
     RankingQueryService,
     RedisService,
+    LocalCacheStore,
+    LayeredCacheStore,
     {
       provide: CACHE_STORE,
-      useExisting: RedisService,
+      useExisting: LayeredCacheStore,
     },
   ],
   exports: [RankingService],


### PR DESCRIPTION

## 📌 작업 요약

랭킹 캐시를 로컬 캐시(L1)/Redis(L2) 구조로 계층화하고, 분산 락을 적용해 다중 인스턴스 환경의 중복 재계산을 방지했습니다.

<br/>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요 (이미지 첨부 가능)

1. 캐시 접근 포트를 분리해 랭킹 도메인과 Redis 구현 간 의존성을 제거했습니다.
2. TTL/LRU 정책을 적용한 로컬 캐시와 Redis 기반 2계층 캐시를 구현했습니다.
3. `Single-flight → 분산 락 → 캐시 재확인 → 재계산` 흐름과 동시성 테스트를 추가했습니다.

<br/>

## 🚨 주요 고민 및 해결 과정

> 주요 고민이나 문제 해결 과정 공유

### 문제

기존 Single-flight는 동일 프로세스의 중복 계산만 방지하므로, 서버가 여러 대일 경우 각 인스턴스에서 같은 랭킹을 다시 계산할 수 있었습니다.

### 해결 과정

Redis의 `SET NX PX`로 분산 락을 획득하고, 소유권 토큰이 일치할 때만 Lua 스크립트로 락을 해제하도록 구현했습니다.

락을 얻지 못한 요청은 캐시 적재를 기다리며, Redis 장애나 대기 시간 초과 시에는 가용성을 위해 자체 계산으로 전환합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로컬 및 분산 환경에서 중복 캐시 계산을 방지하는 캐시 조정 기능을 추가했습니다.
  * 로컬·Redis 2계층 캐시를 지원해 조회 성능과 캐시 재사용성을 높였습니다.
  * 캐시 만료, 용량 제한, 분산 락 및 안전한 락 해제를 지원합니다.
  * 랭킹 조회에 개선된 캐시 처리와 동시 요청 조정 기능을 적용했습니다.

* **테스트**
  * 캐시 적중, 만료, 동시 요청, 분산 락, 장애 대응 시나리오를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->